### PR TITLE
Documentation updates for macOS support pass 1

### DIFF
--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -18,10 +18,11 @@ Before installing Chef Habitat, ensure your system meets these requirements.
 
 ### Operating system and architecture requirements
 
-- Linux kernel 2.6.32 or later on a 64-bit processor
+- Modern Linux kernels on a 64-bit x86_64 Processor (Intel or AMD)
 - Modern Linux kernels on a 64-bit ARM processor
 - Windows Server 2012 or later, or Windows 8 or later on a 64-bit processor
-- macOS 10.9 or later on a 64-bit processor
+- macOS 14 or later on a 64-bit Apple Silicon
+- macOS 14 or later on a 64-bit Intel
 
 ### Docker requirements
 
@@ -51,7 +52,7 @@ You can install a specific Habitat version with `-v <HABITAT_VERSION>`, for exam
 
 ```sh
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo bash -s -- -v 1.6.1245
+    | sudo bash -s -- -v 2.0.504
 ```
 
 ### Install manually
@@ -80,7 +81,7 @@ You can install a specific Habitat version with `-v <HABITAT_VERSION>`, for exam
 
 ```sh
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo bash -s -- -v 1.6.1245
+    | sudo bash -s -- -v 2.0.504
 ```
 
 ### Install using Homebrew
@@ -122,7 +123,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 You can install a specific Habitat version with `-Version <HABITAT_VERSION>`, for example:
 
 ```ps1
-iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version 1.6.1245"
+iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version 2.0.504
 ```
 
 ### Install manually

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -58,7 +58,7 @@ To install Chef Habitat with the install script:
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
     ```
 
-    To install a specific Chef Habitat version,  `-v <HABITAT_VERSION>`, for example:
+    To install a specific Chef Habitat version, use the `-v <HABITAT_VERSION>` flag, for example:
 
     ```shell
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
@@ -107,7 +107,7 @@ To install Chef Habitat with the install script, follow these steps:
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
     ```
 
-    To install a specific Habitat version pass the version number to the install script with `-v <HABITAT_VERSION>`, for example:
+    To install a specific Chef Habitat version, use the `-v <HABITAT_VERSION>` flag, for example:
 
     ```shell
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -22,7 +22,7 @@ Before you install Chef Habitat, confirm that your system meets these requiremen
 - Modern Linux kernels on a 64-bit x86_64 processor (Intel or AMD)
 - Modern Linux kernels on a 64-bit ARM processor
 - Windows Server 2012 or later, or Windows 8 or later on a 64-bit processor
-- macOS 14 or later on a 64-bit Apple Silicon or Intel processors
+- macOS 14 or later on a 64-bit Apple Silicon or Intel processor
 
 ### Docker requirements
 
@@ -112,6 +112,61 @@ brew install hab
 1. [Download Chef Habitat for macOS](https://www.chef.io/downloads)
 
 1. Unzip the Chef Habitat binary to `/usr/local/bin` to add it to your system `PATH`.
+
+### Additional setup to build Habitat packages
+
+If you plan to [build Habitat packages](/packages/pkg_build/) in [Chef Habitat Studio](/studio) on macOS, you must also install or configure the following dependencies.
+
+#### Virtual machine environment
+
+The macOS-native Habitat Studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
+Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions in the same way as Linux chroot-based studios.
+To avoid affecting your host Habitat environment, run the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
+
+#### Download and enable Xcode
+
+Habitat Studio on macOS uses the Clang compiler and linker toolkit provided by Xcode.
+The Xcode Command Line Tools package doesn't include the full SDK headers and frameworks that Habitat Studio requires, so you need the full Xcode application.
+
+1. Download the Xcode version appropriate for your macOS release and save it to your `Applications` folder.
+
+    You need Xcode 15 or later for macOS 14 (Sonoma) and later.
+    See [Xcode Releases](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
+
+1. Point macOS build tools to the full Xcode SDK and accept the license agreement:
+
+    ```shell
+    # Default xcode-select -p may show /Library/Developer/CommandLineTools
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+    # Accept the Xcode license
+    sudo xcodebuild -license accept
+    ```
+
+#### Install the latest Bash shell
+
+Habitat plan files use features available in Bash 5.0 and later.
+Most macOS systems ship with Bash 3.2 due to licensing constraints.
+You can install a compatible version using the `core/bash` Habitat package.
+
+1. Install and configure the `core/bash` Habitat package:
+
+    ```shell
+    # Install core Bash
+    hab pkg install core/bash --binlink --force
+
+    # Make the latest Bash available for build scripts
+    export PATH=/usr/local/bin:$PATH
+
+    # Verify the version---it should show 5.2.x or later
+    bash --version
+    ```
+
+1. To persist this `PATH` change across terminal sessions, add the following line to your shell profile (typically `~/.zshrc` on macOS):
+
+    ```shell
+    export PATH=/usr/local/bin:$PATH
+    ```
 
 ## Install on Windows
 

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -113,6 +113,12 @@ brew install hab
 
 1. Unzip the Chef Habitat binary to `/usr/local/bin` to add it to your system `PATH`.
 
+1. Remove the quarantine attribute that macOS sets on files downloaded through a browser:
+
+    ```shell
+    xattr -d com.apple.quarantine /usr/local/bin/hab
+    ```
+
 ### Additional setup to build Habitat packages
 
 If you plan to [build Habitat packages](/packages/pkg_build/) in [Chef Habitat Studio](/studio) on macOS, you must also install or configure the following dependencies.

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -26,7 +26,7 @@ Before you install Chef Habitat, confirm that your system meets these requiremen
 
 ### Docker requirements
 
-You need Docker Desktop only if you want to use the Docker-based Habitat Studio, which you invoke with the `-D` flag.
+You need Docker Desktop only if you want to use the [Docker-based Chef Habitat Studio](/studio/), which you invoke with the `-D` flag.
 
 If you do need Docker Desktop, install it for your platform:
 
@@ -58,12 +58,12 @@ To install Chef Habitat with the install script:
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
     ```
 
-You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
+    To install a specific Chef Habitat version,  `-v <HABITAT_VERSION>`, for example:
 
-```shell
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo -E bash -s -- -v 2.0.504
-```
+    ```shell
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
+        | sudo -E bash -s -- -v 2.0.504
+    ```
 
 ### Install manually
 
@@ -93,7 +93,7 @@ The following list summarizes what's supported when running Chef Habitat on macO
 
 Progress Chef recommends installing Chef Habitat on macOS with the install script.
 
-To install Chef Habitat with the install script:
+To install Chef Habitat with the install script, follow these steps:
 
 1. Export your Chef Habitat Builder auth token:
 
@@ -107,12 +107,12 @@ To install Chef Habitat with the install script:
     curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
     ```
 
-You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
+    To install a specific Habitat version pass the version number to the install script with `-v <HABITAT_VERSION>`, for example:
 
-```shell
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo -E bash -s -- -v 2.0.504
-```
+    ```shell
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
+        | sudo -E bash -s -- -v 2.0.504
+    ```
 
 ### Install with Homebrew
 
@@ -135,19 +135,19 @@ brew install hab
     xattr -d com.apple.quarantine /usr/local/bin/hab
     ```
 
-### Additional setup to build Habitat packages
+### Additional setup to build Chef Habitat packages
 
-If you plan to [build Habitat packages](/packages/pkg_build/) in [Chef Habitat Studio](/studio) on macOS, you must also install or configure the following dependencies.
+If you plan to [build Chef Habitat packages](/packages/pkg_build/) in [Habitat Studio](/studio) on macOS, you must also install or configure the following dependencies.
 
 #### Virtual machine environment
 
-The macOS-native Habitat Studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
+The macOS-native Chef Habitat Studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
 Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions in the same way as Linux chroot-based studios.
-To avoid affecting your host Habitat environment, run the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
+To avoid affecting your host Chef Habitat environment, run the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
 
 #### Install Xcode Command Line Tools
 
-Habitat Studio on macOS uses the Clang compiler and linker toolkit provided by the Xcode Command Line Tools.
+Chef Habitat Studio on macOS uses the Clang compiler and linker toolkit provided by the Xcode Command Line Tools.
 
 - To install the Xcode Command Line Tools, run the following command:
 

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -44,17 +44,25 @@ Chef Habitat doesn't support alternative containerization platforms.
 
 Progress Chef recommends installing Chef Habitat on Linux with the install script.
 
-To install Chef Habitat with the install script, run the following command:
+To install Chef Habitat with the install script:
 
-```shell
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
-```
+1. Export your Chef Habitat Builder auth token:
+
+    ```shell
+    export HAB_AUTH_TOKEN=<your-token>
+    ```
+
+1. Run the install script:
+
+    ```shell
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
+    ```
 
 You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
 
 ```shell
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo bash -s -- -v 2.0.504
+    | sudo -E bash -s -- -v 2.0.504
 ```
 
 ### Install manually
@@ -85,17 +93,25 @@ The following list summarizes what's supported when running Chef Habitat on macO
 
 Progress Chef recommends installing Chef Habitat on macOS with the install script.
 
-To install Chef Habitat with the install script, run the following command:
+To install Chef Habitat with the install script:
 
-```shell
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
-```
+1. Export your Chef Habitat Builder auth token:
+
+    ```shell
+    export HAB_AUTH_TOKEN=<your-token>
+    ```
+
+1. Run the install script:
+
+    ```shell
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo -E bash
+    ```
 
 You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
 
 ```shell
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-    | sudo bash -s -- -v 2.0.504
+    | sudo -E bash -s -- -v 2.0.504
 ```
 
 ### Install with Homebrew

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -123,49 +123,14 @@ The macOS-native Habitat Studio uses `sandbox-exec` for isolation but shares the
 Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions in the same way as Linux chroot-based studios.
 To avoid affecting your host Habitat environment, run the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
 
-#### Download and enable Xcode
+#### Install Xcode Command Line Tools
 
-Habitat Studio on macOS uses the Clang compiler and linker toolkit provided by Xcode.
-The Xcode Command Line Tools package doesn't include the full SDK headers and frameworks that Habitat Studio requires, so you need the full Xcode application.
+Habitat Studio on macOS uses the Clang compiler and linker toolkit provided by the Xcode Command Line Tools.
 
-1. Download the Xcode version appropriate for your macOS release and save it to your `Applications` folder.
-
-    You need Xcode 15 or later for macOS 14 (Sonoma) and later.
-    See [Xcode Releases](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
-
-1. Point macOS build tools to the full Xcode SDK and accept the license agreement:
+- To install the Xcode Command Line Tools, run the following command:
 
     ```shell
-    # Default xcode-select -p may show /Library/Developer/CommandLineTools
-    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-
-    # Accept the Xcode license
-    sudo xcodebuild -license accept
-    ```
-
-#### Install the latest Bash shell
-
-Habitat plan files use features available in Bash 5.0 and later.
-Most macOS systems ship with Bash 3.2 due to licensing constraints.
-You can install a compatible version using the `core/bash` Habitat package.
-
-1. Install and configure the `core/bash` Habitat package:
-
-    ```shell
-    # Install core Bash
-    hab pkg install core/bash --binlink --force
-
-    # Make the latest Bash available for build scripts
-    export PATH=/usr/local/bin:$PATH
-
-    # Verify the version---it should show 5.2.x or later
-    bash --version
-    ```
-
-1. To persist this `PATH` change across terminal sessions, add the following line to your shell profile (typically `~/.zshrc` on macOS):
-
-    ```shell
-    export PATH=/usr/local/bin:$PATH
+    xcode-select --install
     ```
 
 ## Install on Windows

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -10,23 +10,23 @@ linkTitle = "Install"
     weight = 10
 +++
 
-Chef Habitat provides a command-line interface (CLI) tool called `hab` that you use to build packages, manage services, and interact with Chef Habitat Builder. This section provides installation instructions for Linux, macOS, and Windows.
+Chef Habitat provides a command-line interface (CLI) tool called `hab` that you use to build packages, manage services, and interact with Chef Habitat Builder.
+This section includes installation instructions for Linux, macOS, and Windows.
 
 ## System requirements
 
-Before installing Chef Habitat, ensure your system meets these requirements.
+Before you install Chef Habitat, confirm that your system meets these requirements.
 
 ### Operating system and architecture requirements
 
-- Modern Linux kernels on a 64-bit x86_64 Processor (Intel or AMD)
+- Modern Linux kernels on a 64-bit x86_64 processor (Intel or AMD)
 - Modern Linux kernels on a 64-bit ARM processor
 - Windows Server 2012 or later, or Windows 8 or later on a 64-bit processor
-- macOS 14 or later on a 64-bit Apple Silicon
-- macOS 14 or later on a 64-bit Intel
+- macOS 14 or later on a 64-bit Apple Silicon or Intel processors
 
 ### Docker requirements
 
-Docker Desktop is required only if you want to use the Docker-based Habitat Studio, which you invoke with the `-D` flag.
+You need Docker Desktop only if you want to use the Docker-based Habitat Studio, which you invoke with the `-D` flag.
 
 If you do need Docker Desktop, install it for your platform:
 
@@ -50,9 +50,9 @@ To install Chef Habitat with the install script, run the following command:
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
 ```
 
-You can install a specific Habitat version with `-v <HABITAT_VERSION>`, for example:
+You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
 
-```sh
+```shell
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
     | sudo bash -s -- -v 2.0.504
 ```
@@ -63,23 +63,23 @@ curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/in
 
 1. Extract the `hab.tgz` binary to `/usr/local/bin` or add its location to your `PATH`, for example:
 
-   ```sh
-   tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1
-   ```
+    ```shell
+    tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1
+    ```
 
 ## Install on macOS
 
-The following table summarizes what's supported when running Chef Habitat on macOS:
+The following list summarizes what's supported when running Chef Habitat on macOS:
 
-| Feature | Supported |
-| --- | --- |
-| `hab` CLI | ✅ |
-| `hab pkg install` and package downloads | ✅ |
-| Build packages (native macOS studio) | ✅ |
-| Build Linux packages (Docker studio with `-D` flag) | ✅ (requires Docker Desktop) |
-| Upload packages to Chef Habitat Builder | ✅ |
-| Habitat Supervisor | ❌ |
-| Habitat Services | ❌ |
+| Feature                                             | Supported                     |
+| --------------------------------------------------- | ----------------------------- |
+| `hab` CLI                                           | Yes                           |
+| `hab pkg install` and package downloads             | Yes                           |
+| Build packages (native macOS studio)                | Yes                           |
+| Build Linux packages (Docker studio with `-D` flag) | Yes (requires Docker Desktop) |
+| Upload packages to Chef Habitat Builder             | Yes                           |
+| Habitat Supervisor                                  | No                            |
+| Habitat Services                                    | No                            |
 
 ### Install from the command line
 
@@ -91,18 +91,18 @@ To install Chef Habitat with the install script, run the following command:
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
 ```
 
-You can install a specific Habitat version with `-v <HABITAT_VERSION>`, for example:
+You can install a specific Chef Habitat version with `-v <HABITAT_VERSION>`, for example:
 
-```sh
+```shell
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
     | sudo bash -s -- -v 2.0.504
 ```
 
-### Install using Homebrew
+### Install with Homebrew
 
 To install Chef Habitat with Homebrew, run the following commands:
 
-```bash
+```shell
 brew tap habitat-sh/habitat
 brew install hab
 ```
@@ -111,11 +111,11 @@ brew install hab
 
 1. [Download Chef Habitat for macOS](https://www.chef.io/downloads)
 
-1. Unzip the Habitat binary to `/usr/local/bin` to add it to your system `PATH`.
+1. Unzip the Chef Habitat binary to `/usr/local/bin` to add it to your system `PATH`.
 
 ## Install on Windows
 
-### Install using Chocolatey
+### Install with Chocolatey
 
 Progress Chef recommends installing Chef Habitat on Windows with Chocolatey.
 
@@ -134,9 +134,9 @@ Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 ```
 
-You can install a specific Habitat version with `-Version <HABITAT_VERSION>`, for example:
+You can install a specific Chef Habitat version with `-Version <HABITAT_VERSION>`, for example:
 
-```ps1
+```powershell
 iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1) } -Version 2.0.504
 ```
 
@@ -144,7 +144,7 @@ iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/compone
 
 1. [Download Chef Habitat for Windows](https://www.chef.io/downloads)
 
-1. Unzip the Habitat binary on your computer to `C:\habitat` so that the full path to Chef Habitat is similar to `C:\habitat\hab-<HABITAT_VERSION>-<YYYYMMDDHHMMSS>-x86_64-windows`
+1. Unzip the Chef Habitat binary on your computer to `C:\habitat` so that the full path to Chef Habitat looks like `C:\habitat\hab-<HABITAT_VERSION>-<YYYYMMDDHHMMSS>-x86_64-windows`.
 
     For example, `C:\habitat\hab-0.79.1-20190410221450-x86_64-windows`.
 
@@ -156,9 +156,9 @@ iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/compone
 
 ## Verify installation
 
-To verify that Habitat is installed, run the following commands:
+To verify your installation, run the following commands:
 
-```bash
+```shell
 hab --version
 hab cli setup --help
 ```

--- a/content/install/_index.md
+++ b/content/install/_index.md
@@ -26,7 +26,9 @@ Before installing Chef Habitat, ensure your system meets these requirements.
 
 ### Docker requirements
 
-To run Chef Habitat Studio, you must have Docker Desktop installed:
+Docker Desktop is required only if you want to use the Docker-based Habitat Studio, which you invoke with the `-D` flag.
+
+If you do need Docker Desktop, install it for your platform:
 
 - [Docker Desktop for Linux](https://docs.docker.com/desktop/setup/install/linux/)
 - [Docker Desktop for macOS](https://docs.docker.com/desktop/setup/install/mac-install/)
@@ -66,6 +68,18 @@ curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/in
    ```
 
 ## Install on macOS
+
+The following table summarizes what's supported when running Chef Habitat on macOS:
+
+| Feature | Supported |
+| --- | --- |
+| `hab` CLI | ✅ |
+| `hab pkg install` and package downloads | ✅ |
+| Build packages (native macOS studio) | ✅ |
+| Build Linux packages (Docker studio with `-D` flag) | ✅ (requires Docker Desktop) |
+| Upload packages to Chef Habitat Builder | ✅ |
+| Habitat Supervisor | ❌ |
+| Habitat Services | ❌ |
 
 ### Install from the command line
 

--- a/content/install/install_script_reference.md
+++ b/content/install/install_script_reference.md
@@ -33,9 +33,8 @@ Linux requirements:
 
 macOS requirements:
 
-- `diskutil` for volume management
-- `security` command for keychain operations
-- `launchctl` for daemon management
+- `unzip` for archive extraction
+- `shasum` for checksum verification
 - Administrative privileges for system configuration
 
 ## Usage
@@ -57,7 +56,7 @@ curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/
 : Prints help information
 
 `-v VERSION`
-: Specifies a Habitat version, for example, `1.6.1245` or `1.6.1245/20250905140900`.
+: Specifies a Habitat version, for example, `2.0.504` or `2.0.504/20260505101000`.
 
 `-t TARGET`
 : Specifies the target architecture of the 'hab' program to download.
@@ -68,9 +67,6 @@ curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/
 
 `-u URL`
 : Specifies a custom Habitat Builder URL.
-
-`-b CHANNEL`
-: Specifies a Habitat Builder channel (for temporary use).
 
 `-o ORIGIN`
 : Specifies the origin.
@@ -98,7 +94,7 @@ chmod u+x install.sh
 ### Install a specific version
 
 ```bash
-curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -v 1.6.1245
+curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -v 2.0.504
 ```
 
 ### Install from the unstable channel
@@ -141,21 +137,21 @@ On Linux systems, the script:
 
 ### macOS
 
-macOS installation varies by architecture:
+On macOS the habitat filesystem is rooted at `/opt/hab` instead of `/hab` as newer versions of macOS do not permit creating directories on the root filesystem.
+
+Also, macOS installation varies by architecture:
 
 #### x86-64 (Intel Macs)
 
-- Downloads and installs the hab binary directly to `/usr/local/bin`
-- Uses ZIP archives instead of tar.gz
-- No special volume configuration required
+1. uses a `zip` archive as a hab binary
+1. Downloads and installs the hab binary directly to `/usr/local/bin`
 
 #### AArch64 (Apple Silicon Macs)
 
-- Creates a dedicated APFS volume called "Habitat Store" mounted at `/hab`
-- Configures automatic mounting with the LaunchDaemon
-- Handles FileVault encryption if enabled
-- Updates system configuration files (`/etc/synthetic.conf`, `/etc/fstab`)
-- Uses the full Habitat package installation process
+1. Downloads the hab binary as a `zip` archive
+1. Uses SHA256 checksums for verification
+1. Extracts and temporarily uses the binary to install the full Habitat package
+1. Creates a binlink in `/usr/local/bin/hab` for system-wide access
 
 ## Security and verification
 
@@ -215,12 +211,10 @@ sudo rm -f /bin/hab
 On macOS:
 
 ```bash
-## Remove LaunchDaemon
-sudo rm -f /Library/LaunchDaemons/sh.habitat.bldr.darwin-store.plist
-## Remove volume (if created)
-sudo diskutil apfs deleteVolume "Habitat Store"
-## Remove synthetic.conf entry
-sudo ex /etc/synthetic.conf # manually remove the 'hab' line
+## Remove temporary files
+rm -rf /tmp/hab.*
+## Remove incomplete installation
+sudo rm -f /usr/local/bin/hab
 ```
 
 ## Next steps

--- a/content/install/install_script_reference.md
+++ b/content/install/install_script_reference.md
@@ -143,8 +143,9 @@ Also, macOS installation varies by architecture:
 
 #### x86-64 (Intel Macs)
 
-1. uses a `zip` archive as a hab binary
-1. Downloads and installs the hab binary directly to `/usr/local/bin`
+1. Downloads the hab binary as a `zip` archive
+1. Verifies the download using SHA256 checksums
+1. Installs the hab binary directly to `/usr/local/bin`
 
 #### AArch64 (Apple Silicon Macs)
 
@@ -178,12 +179,6 @@ Permission errors:
 
 - Ensure you have appropriate privileges (sudo on Linux, admin on macOS)
 - Check that target directories are writable
-
-macOS volume creation failures:
-
-- Verify sufficient disk space for the new volume
-- Ensure the root disk has available space
-- Check that FileVault setup is complete if encryption is enabled
 
 ### Debug mode
 

--- a/content/install/install_script_reference.md
+++ b/content/install/install_script_reference.md
@@ -9,7 +9,8 @@ draft = false
     weight = 500
 +++
 
-The Habitat install script (`install.sh`) provides an automated way to download and install the Habitat CLI (`hab`) on Linux and macOS systems. This script handles platform detection, package verification, and system-specific configuration.
+The Habitat install script (`install.sh`) provides an automated way to download and install the Chef Habitat CLI (`hab`) on Linux and macOS systems.
+The script handles platform detection, package verification, and system-specific configuration.
 
 The install script performs these main tasks:
 
@@ -39,7 +40,7 @@ macOS requirements:
 
 ## Usage
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash [options]
 ```
 
@@ -56,10 +57,10 @@ curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/
 : Prints help information
 
 `-v VERSION`
-: Specifies a Habitat version, for example, `2.0.504` or `2.0.504/20260505101000`.
+: Specifies a Chef Habitat version, for example, `2.0.504` or `2.0.504/20260505101000`.
 
 `-t TARGET`
-: Specifies the target architecture of the 'hab' program to download.
+: Specifies the target architecture of the `hab` program to download.
 
   Possible values: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`.
 
@@ -77,7 +78,7 @@ curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/
 
 ### Install the latest stable version
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
 ```
 
@@ -85,7 +86,7 @@ The `curl -sSfL` command is equivalent to `curl --silent --show-error --fail --l
 
 Alternatively, download the file and run it locally, for example:
 
-```bash
+```shell
 curl -OL https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh
 chmod u+x install.sh
 ./install.sh [options]
@@ -93,19 +94,19 @@ chmod u+x install.sh
 
 ### Install a specific version
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -v 2.0.504
 ```
 
 ### Install from the unstable channel
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -c unstable
 ```
 
 ### Install on Linux with AArch64 architecture
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -t aarch64-linux
 ```
 
@@ -117,7 +118,7 @@ The script recognizes these environment variables:
 : Allows you to verify against a custom certificate, such as one generated from a corporate firewall.
 
 `DEBUG`
-: If set, prints shell commands as they execute for troubleshooting.
+: If set, the script prints shell commands as they execute for troubleshooting.
 
 `TMPDIR`
 : Specifies the temporary directory for downloads.
@@ -137,7 +138,7 @@ On Linux systems, the script:
 
 ### macOS
 
-On macOS the habitat filesystem is rooted at `/opt/hab` instead of `/hab` as newer versions of macOS do not permit creating directories on the root filesystem.
+On macOS, Chef Habitat uses `/opt/hab` as the filesystem root instead of `/hab` because newer versions of macOS don't permit creating directories on the root filesystem.
 
 Also, macOS installation varies by architecture:
 
@@ -184,7 +185,7 @@ Permission errors:
 
 Enable debug output to troubleshoot installation issues:
 
-```bash
+```shell
 curl -ssfl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | DEBUG=1 sudo -E bash
 ```
 
@@ -196,7 +197,7 @@ If installation fails partway through, you can manually clean up:
 
 On Linux:
 
-```bash
+```shell
 ## Remove temporary files
 rm -rf /tmp/hab.*
 ## Remove incomplete installation
@@ -205,7 +206,7 @@ sudo rm -f /bin/hab
 
 On macOS:
 
-```bash
+```shell
 ## Remove temporary files
 rm -rf /tmp/hab.*
 ## Remove incomplete installation
@@ -217,13 +218,13 @@ sudo rm -f /usr/local/bin/hab
 After successful installation:
 
 1. Verify the installation: `hab --version`
-2. Set up your origin: `hab origin key generate YOUR_ORIGIN`
+2. Set up your origin: `hab origin key generate <ORIGIN_NAME>`
 3. Review the [CLI setup guide](../install/hab_setup.md) for initial configuration
 4. Take the [Chef Habitat tutorial](https://www.chef.io/training/tutorials) at [Chef Training](https://www.chef.io/training) to learn more about using Habitat.
 
 ## Support
 
-If you have issues with the install script:
+If you run into issues with the install script:
 
 - See the [troubleshooting guide](/troubleshooting/)
 - Visit the [Habitat community forum](https://discourse.chef.io/c/habitat)

--- a/content/origins/origin_keys.md
+++ b/content/origins/origin_keys.md
@@ -80,7 +80,7 @@ See the CLI documentation for more information on the [`hab origin key`](/refere
 
 ### Find your origin keys
 
-Chef Habitat stores your public and private origin keys at `~/.hab/cache/keys` on Linux systems, `C:\hab\cache\keys` on Windows, and at `/hab/cache/keys` inside of the Chef Habitat Studio environment.
+Chef Habitat stores your public and private origin keys at `~/.hab/cache/keys` on Linux, `C:\hab\cache\keys` on Windows, `/opt/hab/cache/keys/` on macOS and at `/hab/cache/keys` inside of the Chef Habitat Studio environment.
 
 #### Find origin keys in a local environment
 
@@ -90,7 +90,7 @@ On Windows:
 Get-ChildItem C:\hab\cache\keys
 ```
 
-On Linux or macOS:
+On Linux and macOS:
 
 ```bash
 ls -la ~/.hab/cache/keys
@@ -104,10 +104,16 @@ On Windows:
 Get-ChildItem C:\hab\cache\keys
 ```
 
-On Linux or macOS:
+On Linux:
 
 ```bash
 ls -la /hab/cache/keys
+```
+
+On macOS:
+
+```bash
+ls -la /opt/hab/cache/keys
 ```
 
 ### Generate origin keys

--- a/content/origins/origin_keys.md
+++ b/content/origins/origin_keys.md
@@ -21,7 +21,8 @@ Prerequisites:
 
 When you create an origin, Chef Habitat Builder automatically generates _origin keys_.
 Origin key cryptography is asymmetric: it has a public origin key that you can distribute freely, and a private origin key (also called a "signing key") that you should distribute only to users of the origin.
-All Chef Habitat Builder users with access to the origin can view the public origin key revisions in the origin key tab (Builder > Origin > Keys) and download the public origin key, but only users with the origin 'administrator' or 'owner' roles can view or download the private origin key, or change the origin key pair.
+If you have access to the origin in Chef Habitat Builder, you can view the public origin key revisions on the **Keys** tab (**Builder** > **Origins** > **Keys**) and download the public origin key.
+To view or download the private origin key or change the origin key pair, you need the 'administrator' or 'owner' role.
 
 | Keys Actions | Read-Only | Member | Maintainer | Administrator | Owner |
 |---------|-------|-------|-------|-------|-------|
@@ -37,14 +38,14 @@ Chef Habitat uses origin keys:
 
 Chef Habitat Builder origin key names follow the format:
 
-```hab
+```text
 <origin>-<datetime>.pub (public key)
 <origin>-<datetime>.sig.key (private key, also called a "signing key")
 ```
 
 For example, in:
 
-```hab
+```text
 testorigin-20190416223046.pub
 testorigin-20190416223046.sig.key
 ```
@@ -56,7 +57,8 @@ testorigin-20190416223046.sig.key
 
 ## The keys tab
 
-When you create an origin, Chef Habitat Builder automatically generates an origin key pair and saves both keys. To view your origin keys on Chef Habitat Builder, navigate to your origin and select the **Keys** tab. (Builder > Origins > Keys) You can always view and download public origin keys, but you can only see the private keys for origins in which you're an administrator or owner.
+When you create an origin, Chef Habitat Builder automatically generates an origin key pair and saves both keys. To view your origin keys on Chef Habitat Builder, go to your origin and select the **Keys** tab (**Builder** > **Origins** > **Keys**).
+You can always view and download public origin keys, but you can only see the private keys for origins in which you're an administrator or owner.
 
 ![Viewing your origin keys](/images/habitat/origin-keys.png)
 
@@ -72,7 +74,7 @@ You can upload origin keys that you generate on the command line to Chef Habitat
 
 ![Example form content for uploading an origin key in Builder](/images/habitat/builder-key-upload.png)
 
-## Managing origin keys with the CLI
+## Manage origin keys with the CLI
 
 Run Chef Habitat CLI commands from your local environment or from within the Chef Habitat Studio.
 
@@ -86,13 +88,13 @@ Chef Habitat stores your public and private origin keys at `~/.hab/cache/keys` o
 
 On Windows:
 
-```PowerShell
+```powershell
 Get-ChildItem C:\hab\cache\keys
 ```
 
 On Linux and macOS:
 
-```bash
+```shell
 ls -la ~/.hab/cache/keys
 ```
 
@@ -106,13 +108,13 @@ Get-ChildItem C:\hab\cache\keys
 
 On Linux:
 
-```bash
+```shell
 ls -la /hab/cache/keys
 ```
 
 On macOS:
 
-```bash
+```shell
 ls -la /opt/hab/cache/keys
 ```
 
@@ -127,7 +129,7 @@ The Chef Habitat CLI creates origin key pairs through two different commands, fo
 
 Create origin keys with the `hab` command:
 
-```hab
+```shell
 hab origin key generate <ORIGIN>
 ```
 
@@ -135,7 +137,7 @@ hab origin key generate <ORIGIN>
 
 To get your public origin key using the command line, use:
 
-```hab
+```shell
 hab origin key download <ORIGIN>
 ```
 
@@ -149,27 +151,27 @@ Creating an origin with the `hab origin create` command registers the origin on 
 
 Upload origin keys with the `hab` command:
 
-```hab
+```shell
 hab origin key upload <ORIGIN>
 ```
 
 Upload the private origin key:
 
-```hab
+```shell
 hab origin key upload --secret <ORIGIN>
 ```
 
 Upload both origin keys at the same time:
 
-```hab
-hab origin key upload  --secfile <PATH_TO_PRIVATE_KEY> --pubfile <PATH_TO_PUBLIC_KEY>
+```shell
+hab origin key upload --secfile <PATH_TO_PRIVATE_KEY> --pubfile <PATH_TO_PUBLIC_KEY>
 ```
 
 ### Import origin keys
 
 Use `hab origin key import` to read the key from a standard input stream into Chef Habitat Builder:
 
-```hab
+```shell
 hab origin key import <enter or paste key>
 hab origin key import <PATH_TO_KEY>
 cat <PATH_TO_KEY> | hab origin key import
@@ -177,18 +179,18 @@ cat <PATH_TO_KEY> | hab origin key import
 
 #### Troubleshoot origin key import
 
-On a macOS, you may encounter an upload failure.
+On macOS, you may encounter an upload failure.
 To remediate this failure:
 
 - Check that your `HAB_AUTH_TOKEN` environment variable is properly set and initialized
 - Add your `SSL_CERT_FILE` to the environment variables in your interactive shell configuration file, such as your `.bashrc`.
 
-```bash
-  export SSL_CERT_FILE=/usr/local/etc/openssl/cert.pem
+```shell
+export SSL_CERT_FILE=/usr/local/etc/openssl/cert.pem
 ```
 
 Initialize the setting from the command line with:
 
-```bash
- source ~/.bashrc
+```shell
+source ~/.bashrc
 ```

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -163,11 +163,13 @@ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
 sudo xcodebuild -license accept
 
 ```
+
 ### Installing Latest Bash
 
 The Habitat Plan files make use of features available in the latest versions of Bash Shell ( version 5 and above). The version of `bash` available on most macOS systems is typically version 3.2 . Latest supported bash can be installed by using the `core/bash` Habitat package. To install and make bash available for building packages perform following steps.
 
 ```bash
+
 # Install core bash
 hab pkg install core/bash --binlink --force
 
@@ -280,10 +282,11 @@ You can now call PowerShell commands to inspect variables (like `Get-ChildItem v
 
 ### macOS Plans Troubleshooting
 
-In macOS we are using a mechanism called `sandbox-exec` for providing the isolation with the host system. This mechanism is configurable through *sandbox scripts*. The way this mechanism works is we start with everything disabled by default and then we enable piece wise access controls that are required for building the packages. A set of standard rules applicable across all the packages are preconfigured in the Studio's *sandbox configuration*. Since plan files are essentially shell
-scripts, that can invoke external commands, which is not possible to determine beforehand, a mechanism is provided called `buildtime_sandbox`, which is simply a shell function that allows to customize (add more permissions if required) the Studio's *sandbox configuration*. Typically if you are observing permission errors during building the package, it's quite likely that some permissions are missing in the Sandbox environment that need to be enabled. You can debug a Studio session that is building a package by running the following command in a separate terminal and checking for the errors reported. Below is a sample output and explanation of the errors from one Studio session.
+In macOS we are using a mechanism called `sandbox-exec` for providing the isolation with the host system. This mechanism is configurable through _sandbox scripts_. The way this mechanism works is we start with everything disabled by default and then we enable piece wise access controls that are required for building the packages. A set of standard rules applicable across all the packages are preconfigured in the Studio's _sandbox configuration_. Since plan files are essentially shell
+scripts, that can invoke external commands, which is not possible to determine beforehand, a mechanism is provided called `buildtime_sandbox`, which is simply a shell function that allows to customize (add more permissions if required) the Studio's _sandbox configuration_. Typically if you are observing permission errors during building the package, it's quite likely that some permissions are missing in the Sandbox environment that need to be enabled. You can debug a Studio session that is building a package by running the following command in a separate terminal and checking for the errors reported. Below is a sample output and explanation of the errors from one Studio session.
 
 ```bash
+
 log stream --predicate 'sender="Sandbox"'
 
 ...
@@ -293,11 +296,14 @@ log stream --predicate 'sender="Sandbox"'
 2026-05-15 11:08:24.741615+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-data /private/var/root/.CFUserTextEncoding
 2026-05-15 11:08:24.750081+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-metadata /Users/seq-test
 ...
+
 ```
-The above errors indicate that the command `git` is getting perissions denied error while running the Studio. These errors can be corrected by providing a *buildtime* configuration using the `buildtime_sandbox` function in your plan file as follows.
+
+The above errors indicate that the command `git` is getting permissions denied error while running the Studio. These errors can be corrected by providing a _buildtime_ configuration using the `buildtime_sandbox` function in your plan file as follows.
 
 ```bash
-# Contents of plan.sh
+
+## Contents of plan.sh
 
 ....
 
@@ -309,6 +315,7 @@ buildtime_sandbox() {
 (allow file-read*)
 '
 }
+
 ...
 
 ```

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -145,6 +145,40 @@ The default channel for non-`core` origin dependencies is the `stable` channel. 
 
 {{< /note >}}
 
+## Additional Setup for macOS
+
+### Downloading and Enabling XCode
+
+For macOS the Clang toolkit provided by the XCode is used. This provides the Compilers and Linkers. To ensure that during the build process, these tools are found correctly, following additional setup is required.
+
+1. Download XCode appropriate for your macOS version. [This link](https://xcodereleases.com/) describes XCode versions and supported macOS Releases.
+2. Save the downloaded XCode in your "Applications folder and run the following Commands
+
+```bash
+
+## Default xcode-select -p may show /Library/Developer/CommandLineTools
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+## Accept the xcode license
+sudo xcodebuild -license accept
+
+```
+### Installing Latest Bash
+
+The Habitat Plan files make use of features available in the latest versions of Bash Shell ( version 5 and above). The version of `bash` available on most macOS systems is typically version 3.2 . Latest supported bash can be installed by using the `core/bash` Habitat package. To install and make bash available for building packages perform following steps.
+
+```bash
+# Install core bash
+hab pkg install core/bash --binlink --force
+
+# Make the latest bash available for the build scripts
+export PATH=/usr/local/bin:$PATH
+
+# Make sure that the version of bash is the correct one.
+bash --version # should show 5.2.x version
+
+```
+
 ## Troubleshooting builds
 
 ### Bash plans: `attach`
@@ -243,3 +277,38 @@ At C:\src\habitat\plan.ps1:26 char:23
 ```
 
 You can now call PowerShell commands to inspect variables (like `Get-ChildItem variable:\`) or files to debug your build.
+
+### macOS Plans Troubleshooting
+
+In macOS we are using a mechanism called `sandbox-exec` for providing the isolation with the host system. This mechanism is configurable through *sandbox scripts*. The way this mechanism works is we start with everything disabled by default and then we enable piece wise access controls that are required for building the packages. A set of standard rules applicable across all the packages are preconfigured in the Studio's *sandbox configuration*. Since plan files are essentially shell
+scripts, that can invoke external commands, which is not possible to determine beforehand, a mechanism is provided called `buildtime_sandbox`, which is simply a shell function that allows to customize (add more permissions if required) the Studio's *sandbox configuration*. Typically if you are observing permission errors during building the package, it's quite likely that some permissions are missing in the Sandbox environment that need to be enabled. You can debug a Studio session that is building a package by running the following command in a separate terminal and checking for the errors reported. Below is a sample output and explanation of the errors from one Studio session.
+
+```bash
+log stream --predicate 'sender="Sandbox"'
+
+...
+2026-05-15 11:08:24.741500+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-data /dev/autofs_nowait
+2026-05-15 11:08:24.741542+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-data /private/var/root/.CFUserTextEncoding
+2026-05-15 11:08:24.741604+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-data /dev/autofs_nowait
+2026-05-15 11:08:24.741615+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-data /private/var/root/.CFUserTextEncoding
+2026-05-15 11:08:24.750081+0530 0x85533    Error       0x0                  0      0    kernel: (Sandbox) Sandbox: git(30931) deny(1) file-read-metadata /Users/seq-test
+...
+```
+The above errors indicate that the command `git` is getting perissions denied error while running the Studio. These errors can be corrected by providing a *buildtime* configuration using the `buildtime_sandbox` function in your plan file as follows.
+
+```bash
+# Contents of plan.sh
+
+....
+
+buildtime_sandbox() {
+   echo '(version 1)
+;; Enable read permissions across file-system
+;; It is possible to enable fine grained access control using
+;; (allow file-read-metadata (subpath "/private/var"))
+(allow file-read*)
+'
+}
+...
+
+```

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -31,9 +31,9 @@ Packages need to be signed with a private origin key at buildtime. Generate an o
 hab origin key generate <ORIGIN>
 ```
 
-The `hab origin key generate` subcommand places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` files (the public key), in the `$HOME/.hab/cache/keys` directory. If you're creating origin keys in the Studio container or you are running as root on a Linux machine, your keys will be stored in `/hab/cache/keys`.
+The `hab origin key generate` subcommand places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` files (the public key), in the `$HOME/.hab/cache/keys` directory. If you're creating origin keys in the Studio container or you are running as root on a Linux machine, your keys will be stored in `/hab/cache/keys` and on a macOS machine they will be stored in `/opt/hab/cache/keys`.
 
-Because the private key is used to sign your artifact, it shouldn't be shared freely; however, if anyone wants to download and use your artifact, then they must have your public key (.pub) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory. If the origin's public key isn't present, Chef Habitat attempts to download it from the Builder endpoint specified by the `--url` argument (<https://bldr.habitat.sh> by default) to `hab pkg install`.
+Because the private key is used to sign your artifact, it shouldn't be shared freely; however, if anyone wants to download and use your artifact, then they must have your public key (.pub) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory (`/opt/hab/cache/keys` on macOS). If the origin's public key isn't present, Chef Habitat attempts to download it from the Builder endpoint specified by the `--url` argument (<https://bldr.habitat.sh> by default) to `hab pkg install`.
 
 ## Passing origin keys into the Studio
 
@@ -93,7 +93,7 @@ The directory where your plan is located is known as the plan context.
 Depending on the platform of your host and your Docker configuration, the behavior of `hab studio enter` may vary. Here is the default behavior listed by host platform:
 
 * **Linux** - A local chrooted Linux Studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command.
-* **Mac** - A Docker container based Linux Studio
+* **Mac** - A local macOS Studio leveraging 'sandbox-exec' utility. You can request to use a Docker container based Linux Studio by passing `-D` flag to the `hab studio enter` command.
 * **Windows** - A local Windows studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you wish to enter.
 
 {{< note >}}

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -1,18 +1,18 @@
 +++
-title = "Building packages"
-description = "Building packages in the Studio"
+title = "Build packages"
+description = "Build packages in Chef Habitat Studio"
 
 
 [menu.packages]
-    title = "Building packages"
+    title = "Build packages"
     identifier = "packages/pkg-build Build your Package"
     parent = "packages"
     weight = 10
 +++
 
-When you've finished creating your plan and call `build` in Chef Habitat Studio, the build script does following steps:
+When you've finished creating your plan and call `build` in Chef Habitat Studio, the build script does the following:
 
-1. Checks that Studio has the private origin key available to sign the artifact.
+1. Checks that Habitat Studio has the private origin key available to sign the artifact.
 1. Downloads the source code from the location in `pkg_source`, if specified
 1. Validates the checksum of the downloaded file using the `pkg_shasum` value, if it's specified.
 1. Extracts the source into a temporary cache.
@@ -23,25 +23,29 @@ When you've finished creating your plan and call `build` in Chef Habitat Studio,
 1. Compresses the package contents (binaries, runtime dependencies, libraries, assets, etc.) into a tarball.
 1. Signs the tarball with your private origin key and gives it a `.hart` file extension.
 
-After the build script completes, you can then upload your package to Chef Habitat Builder, or install and start your package locally.
+After the build script completes, you can upload your package to Chef Habitat Builder, or install and start your package locally.
 
-Packages need to be signed with a private origin key at buildtime. Generate an origin key pair manually by running the following command on your host machine:
+Packages need to be signed with a private origin key at build time.
+Generate an origin key pair manually by running the following command on your host machine:
 
-```bash
+```shell
 hab origin key generate <ORIGIN>
 ```
 
-The `hab origin key generate` subcommand places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` files (the public key), in the `$HOME/.hab/cache/keys` directory. If you're creating origin keys in the Studio container or you are running as root on a Linux machine, your keys will be stored in `/hab/cache/keys` and on a macOS machine they will be stored in `/opt/hab/cache/keys`.
+The `hab origin key generate` subcommand places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` (the public key), in the `$HOME/.hab/cache/keys` directory.
+If you're creating origin keys in the Studio container, or if you're running as root on a Linux machine, your keys are stored in `/hab/cache/keys`.
+On macOS, your keys are stored in `/opt/hab/cache/keys`.
 
 Because the private key is used to sign your artifact, it shouldn't be shared freely; however, if anyone wants to download and use your artifact, then they must have your public key (.pub) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory (`/opt/hab/cache/keys` on macOS). If the origin's public key isn't present, Chef Habitat attempts to download it from the Builder endpoint specified by the `--url` argument (<https://bldr.habitat.sh> by default) to `hab pkg install`.
 
-## Passing origin keys into the Studio
+## Pass origin keys into Habitat Studio
 
-The Habitat Studio is a self-contained and minimal environment, which means that you'll need to share your private origin keys with the Studio to sign artifacts. You can do this in three ways:
+The Habitat Studio is a self-contained, minimal environment, which means you'll need to share your private origin keys with the Studio to sign artifacts.
+You can do this in three ways:
 
 1. Set `HAB_ORIGIN` to the name of the origin you intend to use before entering the Studio:
 
-    ```bash
+    ```shell
     export HAB_ORIGIN=originname
     ```
 
@@ -49,7 +53,7 @@ The Habitat Studio is a self-contained and minimal environment, which means that
 
 1. Set `HAB_ORIGIN_KEYS` to the names of your origins. If you're using more than one origin, separate them with commas:
 
-    ```bash
+    ```shell
     export HAB_ORIGIN_KEYS=originname-internal,originname-test,originname
     ```
 
@@ -57,7 +61,7 @@ The Habitat Studio is a self-contained and minimal environment, which means that
 
 1. Use the `-k` flag (short for "keys") which accepts one or more key names separated by commas with:
 
-    ```bash
+    ```shell
     hab studio -k originname-internal,originname-test enter
     ```
 
@@ -65,16 +69,19 @@ The Habitat Studio is a self-contained and minimal environment, which means that
 
 After you create or receive your private origin key, you can start up the Studio and build your artifact.
 
-## Interactive build
+## Run an interactive build
 
-Any build that you perform from a Chef Habitat Studio is an interactive build. Studio interactive builds allow you to examine the build environment before, during, and after the build.
+Any build that you perform from a Chef Habitat Studio is an interactive build.
+Habitat Studio interactive builds allow you to examine the build environment before, during, and after the build.
 
 The directory where your plan is located is known as the plan context.
 
 1. Change to the parent directory of the plan context.
-1. Create and enter a new Chef Habitat Studio. If you have defined an origin and origin key during `hab cli setup` or by explicitly setting the `HAB_ORIGIN` and `HAB_ORIGIN_KEYS` environment variables, then type the following:
+1. Create and enter a new Chef Habitat Studio.
 
-    ```bash
+    If you defined an origin and origin key during `hab cli setup`, or by explicitly setting the `HAB_ORIGIN` and `HAB_ORIGIN_KEYS` environment variables, run the following command:
+
+    ```shell
     hab studio enter
     ```
 
@@ -82,19 +89,19 @@ The directory where your plan is located is known as the plan context.
 
 1. Enter the following command to create the package.
 
-    ```bash
+    ```shell
     build /src/planname
     ```
 
 1. If the package builds successfully, it's placed into a `results` directory at the same level as your plan.
 
-### Managing the Studio Type (Docker/Linux/Windows)
+### Manage the Habitat Studio type (Docker/Linux/Windows)
 
 Depending on the platform of your host and your Docker configuration, the behavior of `hab studio enter` may vary. Here is the default behavior listed by host platform:
 
-* **Linux** - A local chrooted Linux Studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command.
-* **Mac** - A local macOS Studio leveraging `sandbox-exec`. You can request to use a Docker container based Linux Studio by passing the `-D` flag to the `hab studio enter` command.
-* **Windows** - A local Windows studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you wish to enter.
+* **Linux** - A local chrooted Linux Studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command.
+* **macOS** - A local macOS Studio using `sandbox-exec`. You can request a Docker container-based Linux Studio by passing the `-D` flag to the `hab studio enter` command.
+* **Windows** - A local Windows studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you want to enter.
 
 {{< note >}}
 
@@ -102,11 +109,13 @@ For more details related to Windows containers see [Running Chef Habitat Windows
 
 {{< /note >}}
 
-### Building dependent plans in the Studio
+### Build dependent plans in the studio
 
-Writing plans for multiple packages that are dependent on each other can prove cumbersome when using multiple studios, as you need update dependencies frequently. On the other hand, using a single studio allows you to quickly test your changes by using locally built packages. To do so, you should use a folder structure like this:
+Writing plans for multiple packages that depend on each other can become cumbersome when you use multiple studios, as you need to update dependencies frequently.
+Alternatively, using a single studio lets you quickly test your changes with locally built packages.
+To do this, use a folder structure like this:
 
-```bash
+```shell
 tree projects
 
 projects/
@@ -114,16 +123,18 @@ projects/
 └── project-b
 ```
 
-This way, you can `hab studio enter` in `projects/`. If `project-b` depends on `project-a`, you can call `build project-a && build project-b` for example.
+Then you can run `hab studio enter` in `projects/`.
+If `project-b` depends on `project-a`, you can run `build project-a && build project-b`, for example.
 
-## Non-interactive build
+## Run a non-interactive build
 
-A non-interactive build is one in which Chef Habitat creates a Studio for you, builds the package inside it, and then destroys the Studio, leaving the resulting `.hart` on your computer. Use a non-interactive build when you are sure the build will succeed, or in conjunction with a continuous integration system.
+A non-interactive build is one in which Chef Habitat creates a Studio for you, builds the package inside it, and then destroys the Studio, leaving the resulting `.hart` on your computer.
+Use a non-interactive build when you're sure the build will succeed, or together with a continuous integration system.
 
 1. Change to the parent directory of the plan context.
 1. Build the artifact in an unattended fashion, passing the name of the origin key to the command.
 
-    ```bash
+    ```shell
     hab pkg build yourpackage -k yourname
     ```
 
@@ -131,7 +142,8 @@ A non-interactive build is one in which Chef Habitat creates a Studio for you, b
 
 1. The resulting artifact is inside a directory called `results`, along with any build logs and a build report (`last_build.env`) that includes machine-parsable metadata about the build.
 
-By default, the Studio is reset to a clean state after the package is built; however, _if you are using the Linux version of `hab`_, you can reuse a previous Studio when building your package by specifying the `-R` option when calling the `hab pkg build` subcommand.
+By default, the Studio resets to a clean state after the package is built.
+However, _if you're using the Linux version of `hab`_, you can reuse a previous Studio when building your package by specifying the `-R` option when calling the `hab pkg build` subcommand.
 
 For information on the contents of an installed package, see [Package contents](../reference/package_contents.md).
 
@@ -145,12 +157,12 @@ The default channel for non-`core` origin dependencies is the `stable` channel. 
 
 {{< /note >}}
 
-## Additional Setup for macOS
+## Additional setup for macOS
 
 {{< warning >}}
 
 The macOS native studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
-Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions the way Linux chroot-based studios are.
+Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions in the same way as Linux chroot-based studios.
 To avoid affecting your host Habitat environment, Progress Chef recommends running the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
 
 {{< /warning >}}
@@ -169,11 +181,11 @@ Xcode 15 or later is required for macOS 14 (Sonoma) and later.
 {{< /note >}}
 
 1. Download the Xcode version appropriate for your macOS release.
-   See [xcodereleases.com](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
+   See [Xcode Releases](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
 
 1. Save Xcode to your `Applications` folder, then run the following commands:
 
-```bash
+```shell
 # Default xcode-select -p may show /Library/Developer/CommandLineTools
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
 
@@ -189,7 +201,7 @@ You can install a compatible version using the `core/bash` Habitat package.
 
 Run the following commands in your normal terminal session, outside of the studio:
 
-```bash
+```shell
 # Install core Bash
 hab pkg install core/bash --binlink --force
 
@@ -202,7 +214,7 @@ bash --version
 
 To persist this `PATH` change across terminal sessions, add the following line to your shell profile (typically `~/.zshrc` on macOS):
 
-```bash
+```shell
 export PATH=/usr/local/bin:$PATH
 ```
 
@@ -212,9 +224,9 @@ export PATH=/usr/local/bin:$PATH
 
 While working on plans, you may wish to stop the build and inspect the environment at any point during a build phase (for example download, build, unpack, etc.). In Bash-based plans, Chef Habitat provides an `attach` function for use in your `plan.sh` that functions like a debugging breakpoint and provides an easy read-evaluate-print loop (REPL) at that point. For PowerShell-based plans, you can use the PowerShell built-in `Set-PSBreakpoint` cmdlet prior to running your build.
 
-To use `attach`, insert it into your plan at the point where you would like to use it, for example
+To use `attach`, insert it into your plan at the point where you want to use it, for example:
 
-```bash
+```shell
  do_build() {
    attach
    make
@@ -223,17 +235,17 @@ To use `attach`, insert it into your plan at the point where you would like to u
 
 Now, perform a [build](pkg_build)---we recommend using an interactive studio so you don't need to set up the environment from scratch for every build.
 
-```bash
+```shell
 hab studio enter
 ```
 
-```sh
+```shell
 build yourapp
 ```
 
 The build system proceeds until the point where the `attach` function is invoked, and then drops you into a limited shell:
 
-```bash
+```shell
 # Attaching to debugging session
 From: /src/yourapp/plan.sh @ line 15 :
 
@@ -257,7 +269,7 @@ From: /src/yourapp/plan.sh @ line 15 :
 
 You can use basic Linux commands like `ls` in this environment. You can also use the `help` command the Chef Habitat build system provides in this context to see what other functions can help you debug the plan.
 
-```sh
+```shell
 [1] yourapp(do_build)> help
 Help
   help          Show a list of command or information about a specific command.
@@ -279,17 +291,19 @@ Aliases
   quit-program  Alias for `exit-program`.
 ```
 
-  Type `quit` when you are done with the debugger, and the remainder of the build will continue. If you wish to abort the build entirely, type `quit-program`.
+Type `quit` when you're done with the debugger, and the remainder of the build will continue.
+If you want to abort the build entirely, type `quit-program`.
 
 ### PowerShell plans: `Set-PSBreakpoint`
 
-While there is no `attach` function exposed in a `plan.ps1` file, one can use the native PowerShell cmdlet `Set-PSBreakpoint` to access virtually the same functionality. Instead of adding `attach` to your `Invoke-Build` function, enter the following from inside your studio shell:
+While there is no `attach` function exposed in a `plan.ps1` file, you can use the native PowerShell cmdlet `Set-PSBreakpoint` to access almost the same functionality.
+Instead of adding `attach` to your `Invoke-Build` function, enter the following from inside your studio shell:
 
 ```powershell
 [HAB-STUDIO] Habitat:\src> Set-PSBreakpoint -Command Invoke-Build
 ```
 
-Now upon running `build` you should enter an interactive prompt inside the context of the Invoke-Build function:
+When you run `build`, enter the interactive prompt inside the context of the Invoke-Build function:
 
 ```powershell
    habitat-aspnet-sample: Building
@@ -313,10 +327,10 @@ A set of standard rules is pre-configured in the studio's _sandbox configuration
 Because plan files are shell scripts that can invoke arbitrary external commands, the full set of permissions required isn't known in advance.
 The `buildtime_sandbox` shell function lets you extend the studio's sandbox configuration with additional permissions for your specific plan.
 
-If you observe permission errors during a build, it's likely that the sandbox is blocking access your build needs.
+If you observe permission errors during a build, the sandbox is likely blocking required access.
 To diagnose this, run the following command in a separate terminal while your build runs and watch for denied operations:
 
-```bash
+```shell
 
 log stream --predicate 'sender="Sandbox"'
 
@@ -333,7 +347,7 @@ log stream --predicate 'sender="Sandbox"'
 The above errors show that `git` is being denied access while running in the studio.
 You can resolve these errors by providing a buildtime configuration using the `buildtime_sandbox` function in your plan file, as shown in the following example.
 
-```bash
+```shell
 ## Contents of plan.sh
 
 ....

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -10,10 +10,20 @@ description = "Build packages in Chef Habitat Studio"
     weight = 10
 +++
 
+A Chef Habitat package artifact is a self-contained, signed artifact that bundles an application or library with everything it needs to run---its binaries, runtime dependencies, libraries, and configuration. The build process transforms a plan (a set of build instructions you write) into a `.hart` file: a compressed, cryptographically signed tarball that Chef Habitat can install, run, and distribute.
+
+## macOS system requirements
+
+To build Habitat packages on macOS, make sure you have the following installed and configured:
+
+- [macOS requirements](/install#additional-setup-to-build-habitat-packages)
+
+## How a package is built
+
 When you've finished creating your plan and call `build` in Chef Habitat Studio, the build script does the following:
 
 1. Checks that Habitat Studio has the private origin key available to sign the artifact.
-1. Downloads the source code from the location in `pkg_source`, if specified
+1. Downloads the source code from the location in `pkg_source`, if specified.
 1. Validates the checksum of the downloaded file using the `pkg_shasum` value, if it's specified.
 1. Extracts the source into a temporary cache.
 1. Builds and installs the binary or library using `make` and `make install` for Linux-based builds.
@@ -25,6 +35,12 @@ When you've finished creating your plan and call `build` in Chef Habitat Studio,
 
 After the build script completes, you can upload your package to Chef Habitat Builder, or install and start your package locally.
 
+## Prerequisites
+
+Before building your packages, create a key pair for your origin and share the private key with the Habitat Studio where you'll build the package.
+
+### Generate an origin key pair
+
 Packages need to be signed with a private origin key at build time.
 Generate an origin key pair manually by running the following command on your host machine:
 
@@ -32,18 +48,20 @@ Generate an origin key pair manually by running the following command on your ho
 hab origin key generate <ORIGIN>
 ```
 
-The `hab origin key generate` subcommand places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` (the public key), in the `$HOME/.hab/cache/keys` directory.
+This command places the origin key files, `<ORIGIN>-<TIMESTAMP>.sig.key` (the private key) and `<ORIGIN>-<TIMESTAMP>.pub` (the public key), in your `$HOME/.hab/cache/keys` directory.
+
 If you're creating origin keys in the Studio container, or if you're running as root on a Linux machine, your keys are stored in `/hab/cache/keys`.
 On macOS, your keys are stored in `/opt/hab/cache/keys`.
 
-Because the private key is used to sign your artifact, it shouldn't be shared freely; however, if anyone wants to download and use your artifact, then they must have your public key (.pub) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory (`/opt/hab/cache/keys` on macOS). If the origin's public key isn't present, Chef Habitat attempts to download it from the Builder endpoint specified by the `--url` argument (<https://bldr.habitat.sh> by default) to `hab pkg install`.
+Because the private key is used to sign your artifact, it shouldn't be shared freely; however, if anyone wants to download and use your Habitat artifact, they must have your public key (`.pub`) installed in their local `$HOME/.hab/cache/keys` or `/hab/cache/keys` directory (`/opt/hab/cache/keys` on macOS). If the origin's public key isn't present, Chef Habitat attempts to download it from the Builder endpoint specified by the `--url` argument (<https://bldr.habitat.sh> by default) to `hab pkg install`.
 
-## Pass origin keys into Habitat Studio
+### Pass origin keys into Habitat Studio
 
 The Habitat Studio is a self-contained, minimal environment, which means you'll need to share your private origin keys with the Studio to sign artifacts.
-You can do this in three ways:
 
-1. Set `HAB_ORIGIN` to the name of the origin you intend to use before entering the Studio:
+To share your private origin keys with Habitat Studio, do one of the following:
+
+- Before entering Habitat Studio, set `HAB_ORIGIN` to the name of the origin you intend to use:
 
     ```shell
     export HAB_ORIGIN=originname
@@ -51,7 +69,7 @@ You can do this in three ways:
 
     This approach overrides the `HAB_ORIGIN` environment variable and imports your public and private origin keys into the Studio environment. It also overrides any `pkg_origin` values in the packages that you build. This is useful because you can use it to build your own artifact, as well as to build your own artifacts from other packages' source code, for example, `originname/node` or `originname/glibc`.
 
-1. Set `HAB_ORIGIN_KEYS` to the names of your origins. If you're using more than one origin, separate them with commas:
+- Set `HAB_ORIGIN_KEYS` to the names of your origins. If you're using more than one origin, separate them with commas:
 
     ```shell
     export HAB_ORIGIN_KEYS=originname-internal,originname-test,originname
@@ -59,7 +77,7 @@ You can do this in three ways:
 
     This imports the private origin keys, which must exactly match the origin names for the plans you intend to build.
 
-1. Use the `-k` flag (short for "keys") which accepts one or more key names separated by commas with:
+- Use the `-k` flag (short for "keys") which accepts one or more key names separated by commas with:
 
     ```shell
     hab studio -k originname-internal,originname-test enter
@@ -69,7 +87,9 @@ You can do this in three ways:
 
 After you create or receive your private origin key, you can start up the Studio and build your artifact.
 
-## Run an interactive build
+## Build a package
+
+### Run an interactive build
 
 Any build that you perform from a Chef Habitat Studio is an interactive build.
 Habitat Studio interactive builds allow you to examine the build environment before, during, and after the build.
@@ -85,7 +105,7 @@ The directory where your plan is located is known as the plan context.
     hab studio enter
     ```
 
-    The directory you were in is now mounted as `/src` inside the Studio. By default, a Supervisor runs in the background for iterative testing. You can see the streaming output by running <code>sup-log</code>. Type <code>Ctrl-C</code> to exit the streaming output and <code>sup-term</code> to terminate the background Supervisor. If you terminate the background Supervisor, then running <code>sup-run</code> will restart it along with every service that was previously loaded. You have to explicitly run <code>hab svc unload origin/package</code> to remove a package from the "loaded" list.
+    The directory you were in is now mounted as `/src` inside the Studio. By default, a Supervisor runs in the background for iterative testing. You can see the streaming output by running `sup-log`. Type `Ctrl-C` to exit the streaming output and `sup-term` to terminate the background Supervisor. If you terminate the background Supervisor, then running `sup-run` will restart it along with every service that was previously loaded. You have to explicitly run `hab svc unload origin/package` to remove a package from the "loaded" list.
 
 1. Enter the following command to create the package.
 
@@ -95,13 +115,13 @@ The directory where your plan is located is known as the plan context.
 
 1. If the package builds successfully, it's placed into a `results` directory at the same level as your plan.
 
-### Manage the Habitat Studio type (Docker/Linux/Windows)
+#### Manage the Habitat Studio type (Docker/Linux/Windows)
 
 Depending on the platform of your host and your Docker configuration, the behavior of `hab studio enter` may vary. Here is the default behavior listed by host platform:
 
-* **Linux** - A local chrooted Linux Studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command.
-* **macOS** - A local macOS Studio using `sandbox-exec`. You can request a Docker container-based Linux Studio by passing the `-D` flag to the `hab studio enter` command.
-* **Windows** - A local Windows studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you want to enter.
+- **Linux** - A local chrooted Linux Studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command.
+- **macOS** - A local macOS Studio using `sandbox-exec`. You can request a Docker container-based Linux Studio by passing the `-D` flag to the `hab studio enter` command.
+- **Windows** - A local Windows studio. You can force a Docker-based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you want to enter.
 
 {{< note >}}
 
@@ -109,24 +129,30 @@ For more details related to Windows containers see [Running Chef Habitat Windows
 
 {{< /note >}}
 
-### Build dependent plans in the studio
+#### Build interdependent packages
 
-Writing plans for multiple packages that depend on each other can become cumbersome when you use multiple studios, as you need to update dependencies frequently.
-Alternatively, using a single studio lets you quickly test your changes with locally built packages.
-To do this, use a folder structure like this:
+If you're developing and building multiple packages where one package is dependent on one or more other packages,
+use a single Habitat Studio to build your packages instead of running multiple Habitat Studios.
+This lets you quickly test your changes and is less cumbersome than entering a separate Habitat Studio for each package.
 
-```shell
-tree projects
+To do this, follow these steps:
 
-projects/
-├── project-a
-└── project-b
-```
+1. Organize packages together in folder structure like this:
 
-Then you can run `hab studio enter` in `projects/`.
-If `project-b` depends on `project-a`, you can run `build project-a && build project-b`, for example.
+    ```text
+    projects/
+    ├── project-a
+    └── project-b
+    ```
 
-## Run a non-interactive build
+1. From the `projects/` directory, run `hab studio enter`.
+1. Build your packages in dependency order, for example:
+
+    ```shell
+    build project-a && build project-b
+    ```
+
+### Run a non-interactive build
 
 A non-interactive build is one in which Chef Habitat creates a Studio for you, builds the package inside it, and then destroys the Studio, leaving the resulting `.hart` on your computer.
 Use a non-interactive build when you're sure the build will succeed, or together with a continuous integration system.
@@ -135,10 +161,10 @@ Use a non-interactive build when you're sure the build will succeed, or together
 1. Build the artifact in an unattended fashion, passing the name of the origin key to the command.
 
     ```shell
-    hab pkg build yourpackage -k yourname
+    hab pkg build <PACKAGE_NAME> -k <HAB_ORIGIN_KEYS>
     ```
 
-    > Similar to the `hab studio enter` command above, the type of studio where the build runs is determined by your host platform and `hab pkg build` takes the same `-D` flag to force a Docker environment if desired.
+    Similar to the `hab studio enter` command above, the type of studio where the build runs is determined by your host platform and `hab pkg build` takes the same `-D` flag to force a Docker environment if desired.
 
 1. The resulting artifact is inside a directory called `results`, along with any build logs and a build report (`last_build.env`) that includes machine-parsable metadata about the build.
 
@@ -147,7 +173,7 @@ However, _if you're using the Linux version of `hab`_, you can reuse a previous 
 
 For information on the contents of an installed package, see [Package contents](../reference/package_contents.md).
 
-## Refresh channel
+## Build packages with core origin dependencies from a specific channel
 
 By default, when Habitat builds a plan, it pulls all `core` origin dependencies from the `base` channel. The `base` channel includes all lower level packages from the most recent package refresh. You can change the channel that Habitat pulls `core` origin dependencies from using either the `--refresh-channel` argument in the `hab pkg build` command or by using the `-f` option when entering an interactive studio.
 
@@ -157,66 +183,7 @@ The default channel for non-`core` origin dependencies is the `stable` channel. 
 
 {{< /note >}}
 
-## Additional setup for macOS
-
-{{< warning >}}
-
-The macOS native studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
-Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions in the same way as Linux chroot-based studios.
-To avoid affecting your host Habitat environment, Progress Chef recommends running the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
-
-{{< /warning >}}
-
-### Download and enable Xcode
-
-The macOS studio uses the Clang compiler and linker toolkit provided by Xcode.
-To ensure these tools are found correctly during builds, you need to complete the following setup.
-
-{{< note >}}
-
-Xcode Command Line Tools alone aren't sufficient.
-The studio requires SDK headers and frameworks that the Command Line Tools package doesn't include, so you need the full Xcode application.
-Xcode 15 or later is required for macOS 14 (Sonoma) and later.
-
-{{< /note >}}
-
-1. Download the Xcode version appropriate for your macOS release.
-   See [Xcode Releases](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
-
-1. Save Xcode to your `Applications` folder, then run the following commands:
-
-```shell
-# Default xcode-select -p may show /Library/Developer/CommandLineTools
-sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-
-# Accept the Xcode license
-sudo xcodebuild -license accept
-```
-
-### Install the latest Bash shell
-
-Habitat plan files use features available in Bash 5.0 and later.
-Most macOS systems ship with Bash 3.2 due to licensing constraints.
-You can install a compatible version using the `core/bash` Habitat package.
-
-Run the following commands in your normal terminal session, outside of the studio:
-
-```shell
-# Install core Bash
-hab pkg install core/bash --binlink --force
-
-# Make the latest Bash available for build scripts
-export PATH=/usr/local/bin:$PATH
-
-# Verify the version---it should show 5.2.x or later
-bash --version
-```
-
-To persist this `PATH` change across terminal sessions, add the following line to your shell profile (typically `~/.zshrc` on macOS):
-
-```shell
-export PATH=/usr/local/bin:$PATH
-```
+For information on supported package channels, see the [Habitat package refresh strategy documentation](https://docs.chef.io/habitat/supported_packages/package_refresh_strategy/).
 
 ## Troubleshooting builds
 

--- a/content/packages/pkg_build.md
+++ b/content/packages/pkg_build.md
@@ -93,7 +93,7 @@ The directory where your plan is located is known as the plan context.
 Depending on the platform of your host and your Docker configuration, the behavior of `hab studio enter` may vary. Here is the default behavior listed by host platform:
 
 * **Linux** - A local chrooted Linux Studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command.
-* **Mac** - A local macOS Studio leveraging 'sandbox-exec' utility. You can request to use a Docker container based Linux Studio by passing `-D` flag to the `hab studio enter` command.
+* **Mac** - A local macOS Studio leveraging `sandbox-exec`. You can request to use a Docker container based Linux Studio by passing the `-D` flag to the `hab studio enter` command.
 * **Windows** - A local Windows studio. You can force a Docker based studio by adding the `-D` flag to the `hab studio enter` command. The platform of the spawned container depends on the mode your Docker service is running, which can be toggled between Linux Containers and Windows Containers. Make sure your Docker service is running in the correct mode for the kind of studio you wish to enter.
 
 {{< note >}}
@@ -147,38 +147,63 @@ The default channel for non-`core` origin dependencies is the `stable` channel. 
 
 ## Additional Setup for macOS
 
-### Downloading and Enabling XCode
+{{< warning >}}
 
-For macOS the Clang toolkit provided by the XCode is used. This provides the Compilers and Linkers. To ensure that during the build process, these tools are found correctly, following additional setup is required.
+The macOS native studio uses `sandbox-exec` for isolation but shares the `/opt/hab` filesystem with your host.
+Packages installed during a build persist on the host, and builds aren't guaranteed to be clean between sessions the way Linux chroot-based studios are.
+To avoid affecting your host Habitat environment, Progress Chef recommends running the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon).
 
-1. Download XCode appropriate for your macOS version. [This link](https://xcodereleases.com/) describes XCode versions and supported macOS Releases.
-2. Save the downloaded XCode in your "Applications folder and run the following Commands
+{{< /warning >}}
+
+### Download and enable Xcode
+
+The macOS studio uses the Clang compiler and linker toolkit provided by Xcode.
+To ensure these tools are found correctly during builds, you need to complete the following setup.
+
+{{< note >}}
+
+Xcode Command Line Tools alone aren't sufficient.
+The studio requires SDK headers and frameworks that the Command Line Tools package doesn't include, so you need the full Xcode application.
+Xcode 15 or later is required for macOS 14 (Sonoma) and later.
+
+{{< /note >}}
+
+1. Download the Xcode version appropriate for your macOS release.
+   See [xcodereleases.com](https://xcodereleases.com/) for a list of Xcode versions and their supported macOS releases.
+
+1. Save Xcode to your `Applications` folder, then run the following commands:
 
 ```bash
-
-## Default xcode-select -p may show /Library/Developer/CommandLineTools
+# Default xcode-select -p may show /Library/Developer/CommandLineTools
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
 
-## Accept the xcode license
+# Accept the Xcode license
 sudo xcodebuild -license accept
-
 ```
 
-### Installing Latest Bash
+### Install the latest Bash shell
 
-The Habitat Plan files make use of features available in the latest versions of Bash Shell ( version 5 and above). The version of `bash` available on most macOS systems is typically version 3.2 . Latest supported bash can be installed by using the `core/bash` Habitat package. To install and make bash available for building packages perform following steps.
+Habitat plan files use features available in Bash 5.0 and later.
+Most macOS systems ship with Bash 3.2 due to licensing constraints.
+You can install a compatible version using the `core/bash` Habitat package.
+
+Run the following commands in your normal terminal session, outside of the studio:
 
 ```bash
-
-# Install core bash
+# Install core Bash
 hab pkg install core/bash --binlink --force
 
-# Make the latest bash available for the build scripts
+# Make the latest Bash available for build scripts
 export PATH=/usr/local/bin:$PATH
 
-# Make sure that the version of bash is the correct one.
-bash --version # should show 5.2.x version
+# Verify the version---it should show 5.2.x or later
+bash --version
+```
 
+To persist this `PATH` change across terminal sessions, add the following line to your shell profile (typically `~/.zshrc` on macOS):
+
+```bash
+export PATH=/usr/local/bin:$PATH
 ```
 
 ## Troubleshooting builds
@@ -280,10 +305,16 @@ At C:\src\habitat\plan.ps1:26 char:23
 
 You can now call PowerShell commands to inspect variables (like `Get-ChildItem variable:\`) or files to debug your build.
 
-### macOS Plans Troubleshooting
+### Troubleshoot sandbox permission errors on macOS
 
-In macOS we are using a mechanism called `sandbox-exec` for providing the isolation with the host system. This mechanism is configurable through _sandbox scripts_. The way this mechanism works is we start with everything disabled by default and then we enable piece wise access controls that are required for building the packages. A set of standard rules applicable across all the packages are preconfigured in the Studio's _sandbox configuration_. Since plan files are essentially shell
-scripts, that can invoke external commands, which is not possible to determine beforehand, a mechanism is provided called `buildtime_sandbox`, which is simply a shell function that allows to customize (add more permissions if required) the Studio's _sandbox configuration_. Typically if you are observing permission errors during building the package, it's quite likely that some permissions are missing in the Sandbox environment that need to be enabled. You can debug a Studio session that is building a package by running the following command in a separate terminal and checking for the errors reported. Below is a sample output and explanation of the errors from one Studio session.
+On macOS, Habitat uses `sandbox-exec` for isolation.
+This mechanism is configured through _sandbox scripts_ that start with all access disabled and then selectively grant the permissions required for each build.
+A set of standard rules is pre-configured in the studio's _sandbox configuration_.
+Because plan files are shell scripts that can invoke arbitrary external commands, the full set of permissions required isn't known in advance.
+The `buildtime_sandbox` shell function lets you extend the studio's sandbox configuration with additional permissions for your specific plan.
+
+If you observe permission errors during a build, it's likely that the sandbox is blocking access your build needs.
+To diagnose this, run the following command in a separate terminal while your build runs and watch for denied operations:
 
 ```bash
 
@@ -299,10 +330,10 @@ log stream --predicate 'sender="Sandbox"'
 
 ```
 
-The above errors indicate that the command `git` is getting permissions denied error while running the Studio. These errors can be corrected by providing a _buildtime_ configuration using the `buildtime_sandbox` function in your plan file as follows.
+The above errors show that `git` is being denied access while running in the studio.
+You can resolve these errors by providing a buildtime configuration using the `buildtime_sandbox` function in your plan file, as shown in the following example.
 
 ```bash
-
 ## Contents of plan.sh
 
 ....

--- a/content/plans/plan_writing.md
+++ b/content/plans/plan_writing.md
@@ -134,7 +134,7 @@ app_root/
 
 The build script uses the `plan.ps1` to build your package for Windows, and the `plan.sh` to build your package for Linux on x86-64 processors, Linux on ARM, and macOS. If your application requires different plans for macOS, Linux on ARM processors, or Linux on x86-64 processors---even without hooks and configuration templates---create platform-specific folders that target each platform.
 
-### Create a plan with platform-specific folders
+### Create platform-specific plans
 
 To create a build script that targets specific platforms, follow these steps:
 

--- a/content/plans/plan_writing.md
+++ b/content/plans/plan_writing.md
@@ -1,5 +1,5 @@
 +++
-title = "Writing plans"
+title = "Write a Chef Habitat package plan"
 description = "Documentation for writing Chef Habitat plan files including configuration templates, binds, and exporting"
 summary = "How to write Chef Habitat plans, including configuration templates, binds, exporting, and multi-platform support."
 
@@ -14,7 +14,7 @@ summary = "How to write Chef Habitat plans, including configuration templates, b
 
 In Chef Habitat, the unit of automation is the application itself. This chapter explains the process and workflow for developing a plan that tells Chef Habitat how to build, deploy, and manage your application.
 
-## Writing plans
+## Write a plan
 
 Artifacts are the cryptographically-signed tarballs that are uploaded, downloaded, unpacked, and installed in Chef Habitat. They're built from shell scripts known as plans, but may also include application lifecycle hooks and service configuration files that describe the behavior and configuration of a running service.
 
@@ -22,7 +22,7 @@ At the center of Chef Habitat packaging is the plan. This is a directory made up
 
 To understand plans, review the following example `plan.sh` for [SQLite](https://www.sqlite.org/):
 
-```bash plan.sh
+```shell
 pkg_name=sqlite
 pkg_version=3130000
 pkg_origin=core
@@ -62,7 +62,7 @@ After you finish creating your plan and call `build` in the Chef Habitat Studio,
 2. If specified in `pkg_source`, a compressed file containing the source code is downloaded.
 3. The checksum of that file, specified in `pkg_shasum`, is validated.
 4. The source is extracted into a temporary cache.
-5. Unless they are overridden, callback methods build and install the binary or library with `make` and `make install`, respectively, for Linux-based builds.
+5. Unless they're overridden, callback methods build and install the binary or library with `make` and `make install`, respectively, for Linux-based builds.
 6. Your package contents (binaries, runtime dependencies, libraries, assets, etc.) are then compressed into a tarball.
 7. The tarball is signed with your private origin key and given a `.hart` file extension.
 
@@ -87,7 +87,7 @@ All plans must include a `plan.sh` or `plan.ps1` at the root of the plan context
     To use `hab plan init` as part of your project repo, go to the root of your project repo and run `hab plan init`. It creates a new `habitat` subdirectory with a `plan.sh` (or `plan.ps1` on Windows) based on the name of the parent directory, and includes a `default.toml` file, plus `config` and `hooks` directories for you to populate as needed.
     For example:
 
-    ```bash
+    ```shell
     cd /path/to/<reponame>
     hab plan init
     ```
@@ -95,9 +95,9 @@ All plans must include a `plan.sh` or `plan.ps1` at the root of the plan context
     This creates a new `habitat` directory at `/path/to/<reponame>/habitat`. A plan file is created, and the `pkg_name` variable is set to _\<reponame\>_.
     Any environment variables that you previously set (such as `HAB_ORIGIN`) are used to populate the related `pkg_*` variables.
 
-    If you want to auto-populate more of the `pkg_*` variables, you also have the option of setting them when calling `hab plan init`, as shown in the following example:
+    If you want to autopopulate more of the `pkg_*` variables, you also have the option of setting them when calling `hab plan init`, as shown in the following example:
 
-    ```bash
+    ```shell
     env pkg_svc_user=someuser pkg_deps="(core/make core/coreutils)" \
        pkg_license="('MIT' 'Apache-2.0')" pkg_bin_dirs="(bin sbin)" \
        pkg_version=1.0.0 pkg_description="foo" pkg_maintainer="you" \
@@ -108,13 +108,54 @@ All plans must include a `plan.sh` or `plan.ps1` at the root of the plan context
 
 4. Now that you have stubbed out your plan file in your plan context, open it and begin modifying it to suit your needs.
 
-When writing a plan, it's important to understand that you are defining both how the package is built and the actions Chef Habitat will take when the Supervisor starts and manages the child processes in the package. The following sections explain what you need to do for each phase.
+When writing a plan, it's important to understand that you're defining both how the package is built and the actions Chef Habitat takes when the Supervisor starts and manages the child processes in the package. The following sections explain what you need to do for each phase.
 
-## Writing a plan for multiple platform targets
+## Write a plan for multiple platform targets
 
-You may want to create a plan for an application that runs on multiple platform targets. You can create target-specific folders beneath either the root of your project or a top-level `habitat` folder. Then, save the plan, hooks, and configuration templates for a single platform in that target-specific folder.
+You can create a plan for an application that runs on multiple platform targets.
 
-For example, an application targeting Linux, Linux on ARM, macOS (Apple Silicon), and Windows may have the following structure:
+The build script looks for the base of your plan in the following locations:
+
+- `<APP_ROOT>/<PLATFORM_TARGET>/`
+- `<APP_ROOT>/habitat/<PLATFORM_TARGET>/`
+- `<APP_ROOT>/`
+- `<APP_ROOT>/habitat/`
+
+### Create a basic plan
+
+If you want to create a basic plan for Windows, macOS, and Linux that doesn't include hooks or configuration templates and just requires a plan file, you can use this simpler structure:
+
+```plain
+app_root/
+└── habitat/
+        plan.sh
+        plan.ps1
+```
+
+The build script uses the `plan.ps1` to build your package for Windows, and the `plan.sh` to build your package for Linux on x86-64 processors, Linux on ARM, and macOS. If your application requires different plans for macOS, Linux on ARM processors, or Linux on x86-64 processors---even without hooks and configuration templates---create platform-specific folders that target each platform.
+
+### Create a plan with platform-specific folders
+
+To create a build script that targets specific platforms, follow these steps:
+
+1. Create platform-specific folders one of the following locations:
+
+    - In the root of your project (for example, `<APP_ROOT>/<PLATFORM_TARGET>/`)
+    - In the top-level `habitat` folder (for example, `<APP_ROOT>/habitat/<PLATFORM_TARGET>/`)
+
+      Use the `habitat` folder if you need to create a clean separation between your application and source code.
+      You may not need or want the `habitat` folder if you maintain a separate repository that just contains Habitat plans.
+
+    Replace `<PLATFORM_TARGET>` with one of the following platform-specific folders:
+
+    - `x86_64-linux`
+    - `aarch64-linux`
+    - `aarch64-darwin`
+    - `x86_64-windows`
+
+1. In each platform folder, add the plan file, hooks, and configuration templates for each platform.
+
+For example, you can use the following structure to create plans for an application targeting Linux on x86-64, Linux on ARM, macOS (Apple Silicon), and Windows:
 
 ```plain
 app_root/
@@ -136,37 +177,16 @@ app_root/
             run
 ```
 
-The build script will look for the base of your plan in the following locations:
-
-- `<app_root>/<target>/`
-- `<app_root>/habitat/<target>/`
-- `<app_root>/`
-- `<app_root>/habitat/`
-
-If it finds a plan both inside and outside of a target folder, it uses the target-specific plan when that target is being built. However, we strongly recommend that you don't keep plans both inside and outside of a target folder. We currently allow this only for backward compatibility with existing plans, but we plan to fail builds where a plan exists in both places.
-The best practice is to put each plan in its own target folder.
-
-Of course if your plan doesn't include hooks or configuration templates and just requires a plan file, you may choose this simpler structure:
-
-```plain
-app_root/
-└── habitat/
-        plan.sh
-        plan.ps1
-```
-
 {{< note >}}
 
-Place all plan files inside a `habitat` parent folder to keep a clean separation between your application source code and Habitat-specific files. However, if you maintain a separate repository only for Habitat plans, a `habitat` folder may not be necessary.
+If the build script finds a plan both inside and outside of a platform-specific folder, it uses the target-specific plan when the package is built for that platform. Defining plans both inside and outside of a target folder is only allowed for backward compatibility with existing plans---future Habitat releases will fail builds where a plan exists in both places.
 
 {{< /note >}}
-
-On Windows, only a `plan.ps1` will be used. A `plan.sh` will be used on Linux, Linux on ARM, and macOS. If your application requires different plans for each of these platforms, even without hooks and configuration templates, you'll need to use target folders for each platform.
 
 {{< note >}}
 
 On macOS, the Habitat native studio uses `sandbox-exec` for isolation rather than the `chroot` mechanism used on Linux.
-This means macOS builds have access to host-system libraries and tools via Xcode and aren't as fully isolated as Linux builds.
+This means macOS builds have access to host-system libraries and tools through Xcode and aren't as fully isolated as Linux builds.
 Be explicit about build dependencies in your plan to avoid inadvertently relying on host-provided libraries that won't be available in other environments.
 
 {{< /note >}}
@@ -187,10 +207,10 @@ The following sections describe each of these steps in more detail.
 
 #### Create your package identifier
 
-The origin is a place for you to set default privacy rules, store your packages, and collaborate with teammates. For example, the "core" origin is where the core maintainers of Chef Habitat share packages that are foundational to building other packages. If you would like to browse them, they're located on [Chef Habitat Builder's Core Origin](https://bldr.habitat.sh/#/pkgs/core).
+An origin is where a team sets default privacy rules, stores packages, and collaborates with teammates. For example, the "core" origin is where the core maintainers of Chef Habitat share packages that are foundational to building other packages. To browse them, go to [Chef Habitat Builder's Core Origin](https://bldr.habitat.sh/#/pkgs/core).
 
 Creating artifacts for a specific origin requires access to that origin's private key. The private origin key signs the artifact when the `hab plan build` command builds it.
-Origin keys are kept in `$HOME/.hab/cache/keys` on the host machine when running `hab` as a non-root user, and `/hab/cache/keys` when running as root (including in the Studio).
+Chef Habitat stores origin keys in `$HOME/.hab/cache/keys` on the host machine when running `hab` as a non-root user, and in `/hab/cache/keys` when running as root (including in the Studio).
 For more information on origin keys, see [Keys](../reference/keys.md).
 
 The next important part of your package identifier is the package name. A standard naming convention is to base the package name on the source or project you download and install.
@@ -199,7 +219,7 @@ The next important part of your package identifier is the package name. A standa
 
 You should enter your contact information in your plan.
 
-Most importantly, you should update the `pkg_license` value to indicate the type of license (or licenses) that your source files are licensed under. Valid license types can be found at [https://spdx.org/licenses/](https://spdx.org/licenses/). You can include multiple licenses as an array.
+Most importantly, you should update the `pkg_license` value to indicate the type of license (or licenses) that your source files are licensed under. You can find valid license types at [https://spdx.org/licenses/](https://spdx.org/licenses/). You can include multiple licenses as an array.
 
 {{< note >}}
 
@@ -211,11 +231,11 @@ Because all arrays in the pkg_* settings are shell arrays, they're whitespace de
 
 Add the `pkg_source` value that points to your source files. Any `wget` URL works. However, unless you're downloading a tarball from a public endpoint, you may need to modify how you download your source files and where your `plan.sh` performs the download operation.
 
-Chef Habitat supports retrieving source files from [GitHub](https://github.com). When cloning from GitHub, we recommend HTTPS URIs because they're proxy-friendly, while `git@github` or `git://` are not. To download source from a GitHub repository, implement `do_download()` in your `plan.sh` (or `Invoke-Download` in a `plan.ps1`) and add `core/git` as a build dependency.
+Chef Habitat supports retrieving source files from [GitHub](https://github.com). When cloning from GitHub, use HTTPS URIs because they're proxy-friendly, while `git@github` or `git://` URIs aren't. To download source from a GitHub repository, implement `do_download()` in your `plan.sh` (or `Invoke-Download` in a `plan.ps1`) and add `core/git` as a build dependency.
 Because Chef Habitat doesn't include a system-wide CA cert bundle, use `core/cacerts` and export the `GIT_SSL_CAINFO` environment variable to the Linux path in `core/cacerts`.
 The following example shows this in the `do_download()` callback.
 
-```bash
+```shell
 do_download() {
   export GIT_SSL_CAINFO="$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem"
   git clone https://github.com/chef/chef
@@ -242,11 +262,11 @@ Function Invoke-Download {
 }
 ```
 
-After you have either specified your source in `pkg_source`, or overridden the **do_download()** or **Invoke-Download** callback, create a sha256 checksum for your source archive and enter it as the `pkg_shasum` value. The build script will verify this after it has downloaded the archive.
+After you specify your source in `pkg_source` or override the **do_download()** or **Invoke-Download** callback, create a SHA-256 checksum for your source archive and enter it as the `pkg_shasum` value. The build script verifies this after it downloads the archive.
 
 {{< note >}}
 
-If your computed value doesn't match the value calculated by the `hab-plan-build` script, an error with the expected value will be returned when you execute your plan.
+If your computed value doesn't match the value calculated by the `hab-plan-build` script, the `hab-plan-build` script returns an error with the expected value when you execute your plan.
 
 {{< /note >}}
 
@@ -268,7 +288,7 @@ See [Package contents](../reference/package_contents.md) for more information.
 
 As shown in the earlier example, there are times when you need to override the default behavior of the `hab-plan-build` script. The plan syntax guide lists the default implementations for [build phase callbacks](../reference/build_phase_callbacks.md). If you need to reference specific packages while building your applications or services, override the default implementations, as in the following example.
 
-```bash
+```shell
 pkg_name=httpd
 pkg_origin=core
 pkg_version=2.4.18
@@ -332,15 +352,15 @@ When overriding any callbacks, you may use any of the [variables](../reference/p
 Like build-time setup and installation, you must define runtime behavior for your application or service for the Supervisor. You define this at runtime with Application lifecycle hooks.
 See [Application lifecycle hooks](../reference/application_lifecycle_hooks.md) for more information and examples.
 
-If you only need to start the application or service when the Chef Habitat service starts, you can instead use the `pkg_svc_run` setting and specify the command as a string. When your package is created, a basic run hook will be created by Chef Habitat.
+If you only need to start the application or service when the Chef Habitat service starts, you can instead use the `pkg_svc_run` setting and specify the command as a string. When your package is created, Chef Habitat creates a basic run hook.
 
 You can use any of the [runtime configuration settings](../reference/service_templates.md), either defined by you in your config file, or defined by Chef Habitat.
 
-Once you are done writing your plan, use the studio to [build your package](../packages/pkg_build.md).
+When you're done writing your plan, use the studio to [build your package](../packages/pkg_build.md).
 
 ### Related resources
 
-- [Write plans](#writing-plans): Describes what a plan is and how to create one.
+- [Write plans](#write-a-plan): Describes what a plan is and how to create one.
 - [Add configuration to plans](../reference/config_templates.md): Learn how to make your running service configurable by templatizing configuration files in your plan.
 - [Binary-only packages](binary_wrapper.md): Learn how to create packages from software that comes only in binary form, like off-the-shelf or legacy programs.
 

--- a/content/plans/plan_writing.md
+++ b/content/plans/plan_writing.md
@@ -114,7 +114,7 @@ When writing a plan, it's important to understand that you are defining both how
 
 You may want to create a plan for an application that runs on multiple platform targets. You can create target-specific folders beneath either the root of your project or a top-level `habitat` folder. Then, save the plan, hooks, and configuration templates for a single platform in that target-specific folder.
 
-For example, an application targeting Linux, Linux on ARM, and Windows may have the following structure:
+For example, an application targeting Linux, Linux on ARM, macOS (Apple Silicon), and Windows may have the following structure:
 
 ```plain
 app_root/
@@ -123,6 +123,10 @@ app_root/
 |   └── hooks/
 |           run
 ├── aarch64-linux/
+|   |   plan.sh
+|   └── hooks/
+|           run
+├── aarch64-darwin/
 |   |   plan.sh
 |   └── hooks/
 |           run
@@ -157,7 +161,15 @@ Place all plan files inside a `habitat` parent folder to keep a clean separation
 
 {{< /note >}}
 
-On Windows, only a `plan.ps1` will be used and a `plan.sh` will only be used on Linux or Linux on ARM. If your application requires different plans for Linux and Linux on ARM, even without hooks and configuration templates, you will need to use target folders for each platform.
+On Windows, only a `plan.ps1` will be used. A `plan.sh` will be used on Linux, Linux on ARM, and macOS. If your application requires different plans for each of these platforms, even without hooks and configuration templates, you'll need to use target folders for each platform.
+
+{{< note >}}
+
+On macOS, the Habitat native studio uses `sandbox-exec` for isolation rather than the `chroot` mechanism used on Linux.
+This means macOS builds have access to host-system libraries and tools via Xcode and aren't as fully isolated as Linux builds.
+Be explicit about build dependencies in your plan to avoid inadvertently relying on host-provided libraries that won't be available in other environments.
+
+{{< /note >}}
 
 ### Buildtime workflow
 

--- a/content/reusable/md/habitat_plans_overview.md
+++ b/content/reusable/md/habitat_plans_overview.md
@@ -2,7 +2,7 @@ A plan is the set of instructions, templates, and configuration files that defin
 
 The `habitat` directory includes:
 
-- a plan file (`plan.sh` for Linux systems or `plan.ps1` for Windows)
+- a plan file (`plan.sh` for Linux and macOS systems or `plan.ps1` for Windows)
 - a `default.toml` file defining configuration settings used to render configuration templates
 - an optional `config` directory for configuration templates
 - an optional `hooks` directory for lifecycle hooks

--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -11,6 +11,12 @@ LinkTitle = "Services"
 
 A service is a Chef Habitat package running under a Chef Habitat Supervisor.
 
+{{< note >}}
+
+Chef Habitat Supervisor and Chef Habitat Services are not supported on macOS.
+
+{{< /note >}}
+
 ## Service group
 
 A service group is a set of one or more running services with a shared configuration

--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -13,7 +13,7 @@ A service is a Chef Habitat package running under a Chef Habitat Supervisor.
 
 {{< note >}}
 
-Chef Habitat Supervisor and Chef Habitat Services are not supported on macOS.
+Chef Habitat Supervisor and Chef Habitat Services aren't supported on macOS.
 
 {{< /note >}}
 

--- a/content/studio.md
+++ b/content/studio.md
@@ -76,7 +76,6 @@ The Windows Docker studio doesn't exist as a component like `core/hab-studio` or
 
 The macOS studio uses `sandbox-exec` mechanism to provide the isolation and providing fine grained access control to the studio environment. However, since this is not a full `chroot` environment, some of the paths in the Habitat filesystem `/opt/hab` are being reused with the Host. It is currently recommended to use macOS native studios inside a VM running on the host, so as to not affect the host Habitat environment.
 
-
 ## Studio platform support
 
 Habitat Studio is implemented in four environments and can be invoked from three different operating systems. This matrix shows which studios can be run on the various operating systems.

--- a/content/studio.md
+++ b/content/studio.md
@@ -44,6 +44,10 @@ The purpose of the Studio on Windows is fundamentally the same as on Linux. Howe
 
 One other purpose of the Studio on Windows is to provide a known and common PowerShell environment that the Habitat build program is compatible with. The Windows Studio includes a packaged version of PowerShell that is different from the version that ships with the OS. Entering an interactive Windows Studio makes troubleshooting builds easier because you're placed in the same version of PowerShell that builds packages and the same version used by the Habitat Supervisor at runtime.
 
+### Why do we need it (macOS)
+
+The purpose of Studio on macOS is fundamentally the same as on Linux. However, on macOS, we cannot provide the filesystem isolation using `chroot` as the newer versions of macOS have a very basic `chroot` support that is insufficient. On macOS we are instead leveraging `sandbox-exec` based mechanism to provide the isolation with the Host.
+
 ## What kinds of studios are there?
 
 The Habitat Studio, as an abstract concept, is an environment that provides the required guarantees for builds. The `hab studio` command is the interface that performs the required setup before handing control over to a studio implementation. `pkg build` uses the same setup, but instead of creating an interactive process, it invokes `build` directly in a non-interactive environment.
@@ -68,6 +72,11 @@ The Windows studio uses Junction mounts to provide a consistent filesystem view 
 
 The Windows Docker studio doesn't exist as a component like `core/hab-studio` or `rootless_studio` in the Habitat codebase. Instead, it's created in the release pipeline, using a minimal Windows container as the base and layering in the Windows implementation of `core/hab-studio` to build a Docker image. Like the rootless studio, it can be invoked using only the Docker CLI, with the same additional setup required to set the correct options.
 
+### macOS "native" - aka `core/hab-studio`
+
+The macOS studio uses `sandbox-exec` mechanism to provide the isolation and providing fine grained access control to the studio environment. However, since this is not a full `chroot` environment, some of the paths in the Habitat filesystem `/opt/hab` are being reused with the Host. It is currently recommended to use macOS native studios inside a VM running on the host, so as to not affect the host Habitat environment.
+
+
 ## Studio platform support
 
 Habitat Studio is implemented in four environments and can be invoked from three different operating systems. This matrix shows which studios can be run on the various operating systems.
@@ -78,6 +87,7 @@ Habitat Studio is implemented in four environments and can be invoked from three
 | Linux Docker   | Yes   | Yes   | Yes     |
 | Windows Native | No    | No    | Yes     |
 | Windows Docker | No    | No    | Yes     |
+| macOS Native   | No    | Yes   | No      |
 
 ### Why do we need privileged containers to build (on Linux)?
 
@@ -95,9 +105,9 @@ Today, users can configure agents to run the Docker studio image directly, but t
 
 One question often asked is how to build Windows packages on non-Windows systems. This is often spurred by the ability to build Linux packages on Windows or macOS. However, this isn't a capability provided by the Studio, but by Docker. Docker runs a minimal Linux VM (using Hyper-V on Windows and Hyperkit on macOS) to provide the ability to run Linux containers.
 
-### The "Mac Studio"
+### The "Mac Docker Studio"
 
-Habitat Studio on macOS relies on Docker Desktop creating and running a Docker host inside a headless virtual machine. This gives you the capability to develop and build Linux packages on macOS. macOS itself provides no OS virtualization primitives beyond chroot. Because `hab studio` manages setup and execution of the Docker CLI command, this can create the impression that Studio itself provides Linux package builds on Mac.
+Habitat Docker Studio on macOS (invoked with `-D` CLI option) relies on Docker Desktop creating and running a Docker host inside a headless virtual machine. This gives you the capability to develop and build Linux packages on macOS. macOS itself provides no OS virtualization primitives beyond chroot. Because `hab studio` manages setup and execution of the Docker CLI command, this can create the impression that Studio itself provides Linux package builds on Mac.
 
 ### How the Studio is used
 

--- a/content/studio.md
+++ b/content/studio.md
@@ -22,9 +22,9 @@ In order to explain why that is, so that there is a common starting point, my go
 
 ## Customizing Studio
 
-When you enter Chef Habitat Studio, Chef Habitat will attempt to locate `/src/.studiorc` on Linux and macOS, or `/src/studio_profile.ps1` on Windows, and source it.
+When you enter Chef Habitat Studio, Chef Habitat attempts to locate `/src/.studiorc` on Linux and macOS, or `/src/studio_profile.ps1` on Windows, and source it.
 Think `~/.bashrc` or `$PROFILE`.
-This file can be used to export any environment variables like the ones in `/reference/environment-variables`, as well as any other shell customizations to help you develop your plans from within the Studio.
+Use this file to export any environment variables like the ones in `/reference/environment-variables`, as well as any other shell customizations to help you develop your plans from within the Studio.
 
 To use this feature, place a `.studiorc` (Linux) or `studio_profile.ps1` (Windows) in the current working directory where you run `hab studio enter`.
 
@@ -36,17 +36,17 @@ Chef Habitat will only source `.studiorc` or `studio_profile.ps1` when you run `
 
 ### Why do we need it (Linux)
 
-The primary purpose of the Studio on Linux is to provide environment and filesystem isolation from the build host during the build process. Many common environment variables can influence the build process, such as `PATH` putting user-installed tools ahead of the desired tool versions. Filesystem isolation is important because many tools use common system paths to autodiscover libraries, putting them ahead of the desired Habitat libraries. The result is a known, minimal environment that's portable and consistent across hosts (from laptop to build farm) and forces users to be explicit about how they build and package software.
+The primary purpose of the Studio on Linux is to provide environment and filesystem isolation from the build host during the build process. Many common environment variables can influence the build process, such as `PATH` putting user-installed tools ahead of the desired tool versions. Filesystem isolation is important because many tools use common system paths to autodiscover libraries, putting them ahead of the desired Habitat libraries. The result is a known, minimal environment that's portable and consistent across hosts (from laptop to build farm) and forces you to be explicit about how you build and package software.
 
 ### Why do we need it (Windows)
 
-The purpose of the Studio on Windows is fundamentally the same as on Linux. However, Windows can't achieve filesystem isolation with the "native" studio in the same way Linux can, but this is also less important on Windows. It does provide similar environment isolation, though there are unique constraints imposed by Windows that require certain system paths to be available. For instance, removing system32 libraries and tools would be unnatural at best and would completely break Windows at worst, but the Studio strips all other `PATH` entries (your ProgramFiles applications, for example) to provide a more isolated environment. Registry isolation is also a concern that's different from Linux, but the native studio doesn't provide this isolation. Note that the Docker Windows Studio mentioned below provides much more thorough isolation.
+The purpose of the Studio on Windows is fundamentally the same as on Linux. However, Windows can't achieve filesystem isolation with the "native" studio in the same way Linux can, but this is also less important on Windows. It does provide similar environment isolation, though Windows imposes unique constraints that require certain system paths to be available. For instance, removing system32 libraries and tools would be unnatural at best and would completely break Windows at worst, but the Studio strips all other `PATH` entries (your ProgramFiles applications, for example) to provide a more isolated environment. Registry isolation is also a concern that's different from Linux, but the native studio doesn't provide this isolation. Note that the Docker Windows Studio mentioned below provides much more thorough isolation.
 
-One other purpose of the Studio on Windows is to provide a known and common PowerShell environment that the Habitat build program is compatible with. The Windows Studio includes a packaged version of PowerShell that is different from the version that ships with the OS. Entering an interactive Windows Studio makes troubleshooting builds easier because you're placed in the same version of PowerShell that builds packages and the same version used by the Habitat Supervisor at runtime.
+One other purpose of the Studio on Windows is to provide a known and common PowerShell environment that the Habitat build program is compatible with. The Windows Studio includes a packaged version of PowerShell that's different from the version that ships with the OS. Entering an interactive Windows Studio makes troubleshooting builds easier because it puts you in the same version of PowerShell that builds packages and the same version used by the Habitat Supervisor at runtime.
 
 ### Why do we need it (macOS)
 
-The purpose of Studio on macOS is fundamentally the same as on Linux. However, on macOS, we cannot provide the filesystem isolation using `chroot` as the newer versions of macOS have a very basic `chroot` support that is insufficient. On macOS we are instead leveraging `sandbox-exec` based mechanism to provide the isolation with the Host.
+The purpose of Studio on macOS is fundamentally the same as on Linux. However, on macOS, we can't provide the filesystem isolation using `chroot` as the newer versions of macOS have a very basic `chroot` support that's insufficient. On macOS, Habitat uses a `sandbox-exec`-based mechanism to provide the isolation with the host.
 
 ## What kinds of studios are there?
 
@@ -80,7 +80,7 @@ Progress Chef recommends running the macOS native studio inside a virtual machin
 
 {{< note >}}
 
-Apple has indicated that `sandbox-exec` is deprecated in recent macOS releases.
+Apple deprecated `sandbox-exec` in recent macOS releases.
 Habitat's macOS studio currently depends on this mechanism.
 Progress Chef is tracking this deprecation and will address it in a future release.
 

--- a/content/studio.md
+++ b/content/studio.md
@@ -22,7 +22,7 @@ In order to explain why that is, so that there is a common starting point, my go
 
 ## Customizing Studio
 
-When you enter Chef Habitat Studio, Chef Habitat will attempt to locate `/src/.studiorc` on Linux or `/src/studio_profile.ps1` on Windows and source it.
+When you enter Chef Habitat Studio, Chef Habitat will attempt to locate `/src/.studiorc` on Linux and macOS, or `/src/studio_profile.ps1` on Windows, and source it.
 Think `~/.bashrc` or `$PROFILE`.
 This file can be used to export any environment variables like the ones in `/reference/environment-variables`, as well as any other shell customizations to help you develop your plans from within the Studio.
 
@@ -74,7 +74,17 @@ The Windows Docker studio doesn't exist as a component like `core/hab-studio` or
 
 ### macOS "native" - aka `core/hab-studio`
 
-The macOS studio uses `sandbox-exec` mechanism to provide the isolation and providing fine grained access control to the studio environment. However, since this is not a full `chroot` environment, some of the paths in the Habitat filesystem `/opt/hab` are being reused with the Host. It is currently recommended to use macOS native studios inside a VM running on the host, so as to not affect the host Habitat environment.
+The macOS studio uses `sandbox-exec` to provide isolation and fine-grained access control.
+However, since this isn't a full `chroot` environment, the Habitat filesystem path `/opt/hab` is shared with the host.
+Progress Chef recommends running the macOS native studio inside a virtual machine (for example, UTM or Parallels on Apple Silicon) to avoid affecting your host Habitat environment.
+
+{{< note >}}
+
+Apple has indicated that `sandbox-exec` is deprecated in recent macOS releases.
+Habitat's macOS studio currently depends on this mechanism.
+Progress Chef is tracking this deprecation and will address it in a future release.
+
+{{< /note >}}
 
 ## Studio platform support
 

--- a/content/studio.md
+++ b/content/studio.md
@@ -20,17 +20,16 @@ In order to explain why that is, so that there is a common starting point, my go
 
 {{< readfile file="content/reusable/md/habitat_studio_overview.md" >}}
 
-## Customizing Studio
+## Customize Habitat Studio
 
-When you enter Chef Habitat Studio, Chef Habitat attempts to locate `/src/.studiorc` on Linux and macOS, or `/src/studio_profile.ps1` on Windows, and source it.
-Think `~/.bashrc` or `$PROFILE`.
-Use this file to export any environment variables like the ones in `/reference/environment-variables`, as well as any other shell customizations to help you develop your plans from within the Studio.
+You can customize Chef Habitat Studio's environment by defining [environment variables](/reference/environment_variables/) in a Habitat Studio profile file. This file is similar to `~/.bashrc` or `$PROFILE`.
+When you enter Habitat Studio, Habitat attempts to locate this file and source it.
 
-To use this feature, place a `.studiorc` (Linux) or `studio_profile.ps1` (Windows) in the current working directory where you run `hab studio enter`.
+To use this feature, place a `.studiorc` (Linux) or `studio_profile.ps1` (Windows) in the current working directory where you run `hab studio enter`, then define any [environment variables](/reference/environment_variables/) and any other shell customizations to help you develop your plans from within the Studio.
 
 {{< note >}}
 
-Chef Habitat will only source `.studiorc` or `studio_profile.ps1` when you run `hab studio enter`---it won't be sourced when calling `hab studio run`, `hab studio build`, or `hab pkg build`.
+Chef Habitat will only source `.studiorc` or `studio_profile.ps1` when you run `hab studio enter`---it isn't sourced when calling `hab studio run`, `hab studio build`, or `hab pkg build`.
 
 {{< /note >}}
 
@@ -48,7 +47,7 @@ One other purpose of the Studio on Windows is to provide a known and common Powe
 
 The purpose of Studio on macOS is fundamentally the same as on Linux. However, on macOS, we can't provide the filesystem isolation using `chroot` as the newer versions of macOS have a very basic `chroot` support that's insufficient. On macOS, Habitat uses a `sandbox-exec`-based mechanism to provide the isolation with the host.
 
-## What kinds of studios are there?
+## What kinds of Habitat Studios are there?
 
 The Habitat Studio, as an abstract concept, is an environment that provides the required guarantees for builds. The `hab studio` command is the interface that performs the required setup before handing control over to a studio implementation. `pkg build` uses the same setup, but instead of creating an interactive process, it invokes `build` directly in a non-interactive environment.
 
@@ -116,7 +115,7 @@ One question often asked is how to build Windows packages on non-Windows systems
 
 ### The "Mac Docker Studio"
 
-Habitat Docker Studio on macOS (invoked with `-D` CLI option) relies on Docker Desktop creating and running a Docker host inside a headless virtual machine. This gives you the capability to develop and build Linux packages on macOS. macOS itself provides no OS virtualization primitives beyond chroot. Because `hab studio` manages setup and execution of the Docker CLI command, this can create the impression that Studio itself provides Linux package builds on Mac.
+Habitat Docker Studio on macOS (invoked with `-D` CLI option) relies on Docker Desktop creating and running a Docker host inside a headless virtual machine. This gives you the capability to develop and build Linux packages on macOS. macOS itself provides no OS virtualization primitives beyond chroot. Because `hab studio` manages setup and execution of the Docker CLI command, this can create the impression that Studio itself provides Linux package builds on macOS.
 
 ### How the Studio is used
 

--- a/content/sup/_index.md
+++ b/content/sup/_index.md
@@ -12,6 +12,12 @@ linkTitle = "Supervisors"
 
 The Supervisor is a process manager that has two primary responsibilities. First, it starts and monitors child services defined in the plan it's running. Second, it receives and acts on information from the other Supervisors to which it's connected. A service is reconfigured through application lifecycle hooks if its configuration has changed.
 
+{{< note >}}
+
+Chef Habitat Supervisor and Chef Habitat Services are not supported on macOS.
+
+{{< /note >}}
+
 ## The Supervisor ring
 
 Supervisors typically run in a network, which we refer to as a *ring* (although it's more like a peer-to-peer network than a circular ring). The ring can be very large; it can contain hundreds or thousands of Supervisors. The membership list of this ring is maintained independently by each Supervisor and is known as the *census*.

--- a/content/sup/_index.md
+++ b/content/sup/_index.md
@@ -14,7 +14,7 @@ The Supervisor is a process manager that has two primary responsibilities. First
 
 {{< note >}}
 
-Chef Habitat Supervisor and Chef Habitat Services are not supported on macOS.
+Chef Habitat Supervisor and Chef Habitat Services aren't supported on macOS.
 
 {{< /note >}}
 

--- a/content/troubleshooting.md
+++ b/content/troubleshooting.md
@@ -33,12 +33,6 @@ Permission errors:
 - Ensure you have appropriate privileges (`sudo` on Linux, admin on macOS).
 - Check that target directories are writable.
 
-macOS volume creation failures:
-
-- Verify sufficient disk space for the new volume.
-- Ensure the root disk has available space.
-- Check that FileVault setup is complete if encryption is enabled.
-
 ### Permission errors on Linux or macOS
 
 #### Problem

--- a/content/troubleshooting.md
+++ b/content/troubleshooting.md
@@ -171,7 +171,7 @@ $env:PATH += ";C:\habitat\hab-VERSION-x86_64-windows\"
 
 #### Solution
 
-**On macOS (native studio):**
+On macOS (native studio):
 
 1. Verify that Xcode is installed and configured correctly:
 
@@ -193,7 +193,7 @@ $env:PATH += ";C:\habitat\hab-VERSION-x86_64-windows\"
 
    For details on how to resolve sandbox permission errors, see [Troubleshoot sandbox permission errors on macOS](../packages/pkg_build#troubleshoot-sandbox-permission-errors-on-macos).
 
-**On all platforms (Docker studio):**
+On all platforms (Docker studio):
 
 1. Verify that Docker is running.
 1. Check for conflicting containers:

--- a/content/troubleshooting.md
+++ b/content/troubleshooting.md
@@ -171,6 +171,30 @@ $env:PATH += ";C:\habitat\hab-VERSION-x86_64-windows\"
 
 #### Solution
 
+**On macOS (native studio):**
+
+1. Verify that Xcode is installed and configured correctly:
+
+   ```bash
+   xcode-select -p
+   ```
+
+   If the output shows `/Library/Developer/CommandLineTools`, run the following command to point to the full Xcode installation:
+
+   ```bash
+   sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+   ```
+
+1. If the studio starts but you see sandbox permission errors during a build, run the following command in a separate terminal to identify which operations are being denied:
+
+   ```bash
+   log stream --predicate 'sender="Sandbox"'
+   ```
+
+   For details on how to resolve sandbox permission errors, see [Troubleshoot sandbox permission errors on macOS](../packages/pkg_build#troubleshoot-sandbox-permission-errors-on-macos).
+
+**On all platforms (Docker studio):**
+
 1. Verify that Docker is running.
 1. Check for conflicting containers:
 

--- a/content/upgrade/_index.md
+++ b/content/upgrade/_index.md
@@ -100,3 +100,5 @@ To upgrade a Supervisor from Habitat 1.6 to 2:
   ```ps1
   iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/migrate.ps1) } --auth <HAB_AUTH_TOKEN>"
   ```
+
+- Chef Habitat Supervisor is not supported on macOS

--- a/content/upgrade/_index.md
+++ b/content/upgrade/_index.md
@@ -101,4 +101,4 @@ To upgrade a Supervisor from Habitat 1.6 to 2:
   iex "& { $(irm https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/migrate.ps1) } --auth <HAB_AUTH_TOKEN>"
   ```
 
-- Chef Habitat Supervisor is not supported on macOS
+- Chef Habitat Supervisor isn't supported on macOS


### PR DESCRIPTION
## Description

Documentation updates for the upcoming Chef Habitat release with macOS support. This is the first pass.

## Chef Habitat versions

Versions 2.0 

## Issues resolved

## Related PRs

## Checklist

- [ ] spellcheck
- [ ] all tests pass
