### PR TITLE
CONT-29125: Add Link Checker skill and refactor link-reviewer agent

### DIFF
--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -83,11 +83,13 @@ The default published site URL for Chef Habitat documentation is `https://docs.c
 
 ### Step 2 — Run the Link Checker skill (live site check)
 
+> **Skip this step** if the user chose "Markdown source files only" in Step 1 — proceed directly to Step 3.
+
 Invoke the **Link Checker** skill (`/.github/skills/link-checker/SKILL.md`) with the target URL.
 
 The skill will:
-- Install `linkchecker` if not already available
-- Run `linkchecker --no-robots --output=csv --check-extern --timeout=10 <url>`
+- Verify `linkchecker` is available (and surface a clear install error if not)
+- Run `linkchecker --no-robots --file-output=csv --check-extern --timeout=10 <url>`
 - Return structured lists of broken links (`$broken`) and redirected links (`$redirected`)
 
 Collect the results. Do not start generating the report yet.
@@ -146,6 +148,6 @@ Only after explicit human confirmation, edit Markdown source files to replace ap
 ## Additional constraints
 
 - Do not edit files before presenting the report and receiving explicit confirmation from a human.
-- If a URL fetch or linkchecker run fails, flag affected links as "unverifiable" and include them for manual review.
+- If a `linkchecker` run fails or a URL cannot be reached during crawling, flag affected links as "unverifiable" and include them for manual review.
 - Some URLs may return errors because they block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
 - Explicitly label recommendations as drafts that require human review.

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -1,7 +1,7 @@
 ---
-description: "Use when reviewing documentation for broken, outdated, or redirected links. Scans Markdown files, fetches URLs to verify they are live, identifies issues like http to https upgrades, master to main branch references, and outdated domains, then produces a report and optionally applies fixes."
+description: "Use when reviewing documentation for broken, outdated, or redirected links. Runs the Link Checker skill against the published documentation site to detect broken and redirected links at scale, then applies pattern-based checks to Markdown source files for common issues. Produces a report and optionally applies fixes."
 name: "Link Reviewer"
-tools: [read, search, web, edit]
+tools: [read, search, shell, edit]
 ---
 ## Purpose
 
@@ -67,43 +67,85 @@ If a task requires capabilities outside your scope, explain the limitation and s
 
 ## Link review workflow
 
-1. **Discover files**: Search for all `.md` files in the scope the user specifies: a single file, a folder, or the whole repository. If no scope is given, ask the user to clarify.
-2. **Extract links**: Read each file and collect all hyperlinks, both inline `[text](url)` and reference-style links. Skip relative links that don't start with `http`.
-3. **Verify links**: For each URL, fetch it and classify it:
-   - Returns 200 OK (live and correct)
-   - Redirects (capture the final destination URL and redirect chain)
-   - Returns 404 or fails (broken)
-   - Is unverifiable due to auth, rate limiting, or network restrictions (flag as "unverifiable")
-4. **Flag patterns**: Also flag issues through pattern matching:
-   - `http://` URLs that should be `https://`
-   - GitHub links pointing to a `master` branch (suggest `main`)
-   - Known outdated domains, including:
-     - `docs.microsoft.com` to `learn.microsoft.com`
-     - `docs.openshift.com` to `docs.redhat.com`
-     - Old Google Cloud URLs (`cloud.google.com/container-registry`) to Artifact Registry equivalents
-5. **Produce a report**: Present a structured table of all findings grouped by file, with line number, link text, current URL, issue type, and suggested replacement URL.
-6. **Ask for confirmation**: Ask whether to apply all fixes, select specific fixes, or apply none.
-7. **Apply fixes**: Only after explicit human confirmation, edit files to replace approved URLs. Do not change link text.
+This agent uses two complementary approaches to find link issues:
+
+1. **Live site check (Link Checker skill)** — runs `linkchecker` against the published documentation site to detect broken links, redirects, and HTTP errors across all pages at once, without fetching each URL individually.
+2. **Markdown pattern check** — reads Markdown source files to catch issues that only appear in the source (for example, `http://` URLs not yet published, `master` branch references, and known outdated domains).
+
+### Step 1 — Clarify scope
+
+If the user has not specified a scope, ask whether they want to:
+- Check the full published site (recommended for a broad sweep)
+- Check a specific section of the published site (provide a URL prefix)
+- Check only Markdown source files (for pre-publication or draft content)
+
+The default published site URL for Chef Habitat documentation is `https://docs.chef.io/habitat/`.
+
+### Step 2 — Run the Link Checker skill (live site check)
+
+Invoke the **Link Checker** skill (`/.github/skills/link-checker/SKILL.md`) with the target URL.
+
+The skill will:
+- Install `linkchecker` if not already available
+- Run `linkchecker --no-robots --output=csv --check-extern --timeout=10 <url>`
+- Return structured lists of broken links (`$broken`) and redirected links (`$redirected`)
+
+Collect the results. Do not start generating the report yet.
+
+### Step 3 — Run pattern checks on Markdown source files
+
+Search for all `.md` files in the scope the user specifies. For each file, extract all hyperlinks
+(inline `[text](url)` and reference-style) and flag:
+
+- `http://` URLs that should be `https://`
+- GitHub links pointing to a `master` branch (suggest `main`)
+- Known outdated domains:
+  - `docs.microsoft.com` to `learn.microsoft.com`
+  - `docs.openshift.com` to `docs.redhat.com`
+  - Old Google Cloud URLs (`cloud.google.com/container-registry`) to Artifact Registry equivalents
+
+Do not fetch these URLs — flag them by pattern only.
+
+### Step 4 — Produce a report
+
+Combine results from Steps 2 and 3. Present findings in two sections:
+
+**Section A: Live site results** (from linkchecker)
+
+Group by issue type (broken, redirected). For each finding:
+
+| URL | Result | Found on page |
+|-----|--------|--------------|
+| https://example.com/old | 404 Not Found | https://docs.chef.io/habitat/page/ |
+
+**Section B: Markdown source pattern issues**
+
+Group by file. For each file:
+
+| Line | Link text | Current URL | Issue | Suggested URL |
+|------|-----------|-------------|-------|---------------|
+| 42 | Docker docs | http://docs.docker.com/... | http to https | https://docs.docker.com/... |
+
+After both sections, provide a summary:
+
+> Found X broken links, Y redirects (live site), and Z pattern issues in Markdown source across N files.
+
+### Step 5 — Ask for confirmation
+
+Ask whether to apply all fixes, select specific fixes, or apply none.
+
+### Step 6 — Apply fixes
+
+Only after explicit human confirmation, edit Markdown source files to replace approved URLs.
+
+- Do not change link text, only URL targets.
+- Do not modify internal relative links.
+- Do not guess replacement URLs — suggest replacements only when verified through the live check or a known pattern.
+- Explicitly label all recommendations as drafts requiring human review.
 
 ## Additional constraints
 
 - Do not edit files before presenting the report and receiving explicit confirmation from a human.
-- Do not change link text, only URL targets.
-- Do not flag or modify internal relative links.
-- Do not guess replacement URLs. Suggest replacements only when verified through a live fetch or known pattern.
-- If a URL fetch fails, flag it as "unverifiable" and include it for manual review.
+- If a URL fetch or linkchecker run fails, flag affected links as "unverifiable" and include them for manual review.
+- Some URLs may return errors because they block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
 - Explicitly label recommendations as drafts that require human review.
-
-## Report format
-
-Group findings by file. For each file, produce a table:
-
-| Line | Link text | Current URL | Issue | Suggested URL |
-|------|-----------|-------------|-------|---------------|
-| 42 | Docker docs | https://docs.docker.com/engine/... | http to https and redirect | https://docs.docker.com/engine/... |
-
-After all tables, provide a summary:
-
-> Found X broken links, Y redirects, and Z pattern issues across N files.
-
-If no issues are found in a file, skip it from the report.

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -85,10 +85,28 @@ The default published site URL for Chef Habitat documentation is `https://docs.c
 
 > **Skip this step** if the user chose "Markdown source files only" in Step 1 — proceed directly to Step 3.
 
-Invoke the **Link Checker** skill (`/.github/skills/link-checker/SKILL.md`) with the target URL.
+Before invoking the skill, verify that `linkchecker` is installed:
+
+```powershell
+$lc = Get-Command linkchecker -ErrorAction SilentlyContinue
+if (-not $lc) { Write-Host "NOT_FOUND" } else { Write-Host "FOUND" }
+```
+
+If `linkchecker` is **not found**, do not silently skip the live check. Instead:
+
+1. Inform the user that `linkchecker` is not installed.
+2. Ask: *"Would you like me to install it now using `pipx install linkchecker`? This will pull the package and its dependencies from PyPI."*
+3. Wait for explicit confirmation before running any install command.
+4. If the user confirms, run:
+   ```powershell
+   pipx install linkchecker
+   ```
+   Then verify the install succeeded before proceeding.
+5. If the user declines, skip the live site check, note it in the final report as "skipped — linkchecker not installed", and proceed to Step 3.
+
+Once `linkchecker` is confirmed available, invoke the **Link Checker** skill (`/.github/skills/link-checker/SKILL.md`) with the target URL.
 
 The skill will:
-- Verify `linkchecker` is available (and surface a clear install error if not)
 - Run `linkchecker --no-robots --file-output=csv --check-extern --timeout=10 <url>`
 - Return structured lists of broken links (`$broken`) and redirected links (`$redirected`)
 

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -170,6 +170,37 @@ Only after explicit human confirmation, edit Markdown source files to replace ap
 - Some URLs may return errors because they block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
 - Explicitly label recommendations as drafts that require human review.
 
+## Git commits and DCO sign-off
+
+This repository requires a Developer Certificate of Origin (DCO) sign-off on every commit. The `Signed-off-by` trailer is a legal certification that a human is taking responsibility for the contribution — it must come from the human author, not from Copilot.
+
+Always include the human user's `Signed-off-by` trailer in every commit message:
+
+```
+Signed-off-by: Name <email>
+```
+
+Use `git config user.name` and `git config user.email` to confirm the correct identity before committing. The `Co-authored-by: Copilot` trailer is still appropriate but does not satisfy the DCO requirement on its own.
+
+If any commits on the branch are missing a human `Signed-off-by`, use an interactive rebase to add it before pushing:
+
+```powershell
+git rebase -i main
+# Mark each commit as 'reword', then add the Signed-off-by trailer
+```
+
+Or amend the most recent commit directly:
+
+```powershell
+git commit --amend --signoff
+```
+
+Force-push after a rebase:
+
+```powershell
+git push --force-with-lease
+```
+
 ## Pushing changes to GitHub
 
 The `habitat-sh` organization enforces SAML SSO. A `git push` may fail with a 403 error even after a successful `gh auth refresh`. If this happens:

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -126,17 +126,24 @@ Search for all `.md` files in the scope the user specifies. For each file, extra
 
 Do not fetch these URLs — flag them by pattern only.
 
-### Step 4 — Produce a report
+### Step 4 — Produce a report and CSV
 
-Combine results from Steps 2 and 3. Present findings in two sections:
+Combine results from Steps 2 and 3. Present findings in two sections in the chat, then always export a CSV file.
 
 **Section A: Live site results** (from linkchecker)
 
-Group by issue type (broken, redirected). For each finding:
+Group by issue type (broken, redirected). For each finding, research a suggested fix before presenting:
 
-| URL | Result | Found on page |
-|-----|--------|--------------|
-| https://example.com/old | 404 Not Found | https://docs.chef.io/habitat/page/ |
+- For internal 404s: check whether the page exists at a corrected path (for example, a versioned URL or a restructured section) by running a targeted `curl` check against the likely corrected URL.
+- For external 404s: check whether a known redirect or replacement URL exists (for example, updated Kubernetes docs paths, retired projects).
+- For 403s and other non-404 errors: classify as "unverifiable — verify manually" rather than broken.
+- For placeholder `mailto:` addresses in code examples: classify as "placeholder — no action needed".
+
+Present findings in the chat:
+
+| Link name | URL | Result | Found on page | Category | Suggested fix |
+|-----------|-----|--------|---------------|----------|---------------|
+| Example link | https://example.com/old | 404 Not Found | https://docs.chef.io/habitat/page/ | External — page moved | Update to https://example.com/new (confirmed 200 OK) |
 
 **Section B: Markdown source pattern issues**
 
@@ -150,9 +157,28 @@ After both sections, provide a summary:
 
 > Found X broken links, Y redirects (live site), and Z pattern issues in Markdown source across N files.
 
-### Step 5 — Ask for confirmation
+**Always export a CSV file** after presenting the in-chat summary. Ask the user where to save it, or default to the Desktop if they don't specify. The CSV must include the following columns:
 
-Ask whether to apply all fixes, select specific fixes, or apply none.
+| Column | Description |
+|--------|-------------|
+| Link name | The link text as it appears on the published page (from the `name` field in linkchecker output, or the Markdown link text for source pattern issues) |
+| Broken URL | The URL that failed |
+| HTTP result | The HTTP status code or error message |
+| Found on page | The full URL of the page on docs.chef.io where the broken link appears |
+| Category | A plain-English classification of the issue type |
+| Suggested fix | A specific verified replacement URL, or a clear recommendation (for example, "Remove — project retired" or "Verify manually in browser") — never leave this blank |
+| Approved? (Y/N) | Blank — for the human reviewer to complete |
+| Fixed? (Y/N) | Blank — for tracking progress |
+
+The **Link name** must come from the `name` field in the linkchecker CSV output for live site findings. This reflects the actual visible link text on the rendered page, which makes it easy for reviewers to locate the link on the site.
+
+### Step 5 — Ask the user to review the CSV
+
+After exporting the CSV, tell the user:
+
+> The CSV has been saved to [path]. Please review the **Suggested fix** column and mark each row **Y** in the **Approved?** column for fixes you'd like applied. Share the reviewed CSV back when you're ready, or let me know which fixes to apply.
+
+Do not proceed to Step 6 until the user explicitly confirms which fixes to apply.
 
 ### Step 6 — Apply fixes
 

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -92,17 +92,17 @@ $lc = Get-Command linkchecker -ErrorAction SilentlyContinue
 if (-not $lc) { Write-Host "NOT_FOUND" } else { Write-Host "FOUND" }
 ```
 
-If `linkchecker` is **not found**, do not silently skip the live check. Instead:
+If `linkchecker` is **not found**, do not attempt to install it. Instead, tell the user:
 
-1. Inform the user that `linkchecker` is not installed.
-2. Ask: *"Would you like me to install it now using `pipx install linkchecker`? This will pull the package and its dependencies from PyPI."*
-3. Wait for explicit confirmation before running any install command.
-4. If the user confirms, run:
-   ```powershell
-   pipx install linkchecker
-   ```
-   Then verify the install succeeded before proceeding.
-5. If the user declines, skip the live site check, note it in the final report as "skipped — linkchecker not installed", and proceed to Step 3.
+> `linkchecker` isn't installed, so the live site check can't run. To enable it, install `linkchecker` in your terminal before starting this agent:
+>
+> ```shell
+> pipx install linkchecker
+> ```
+>
+> Once installed, re-run the agent to get the full report. To continue now with Markdown source checks only, say "skip live check".
+
+Then stop and wait for the user's response. If they say "skip live check", note the live site check as "skipped — linkchecker not installed" in the final report and proceed to Step 3. Otherwise, do not continue.
 
 Once `linkchecker` is confirmed available, invoke the **Link Checker** skill (`/.github/skills/link-checker/SKILL.md`) with the target URL.
 

--- a/.github/agents/link-reviewer.agent.md
+++ b/.github/agents/link-reviewer.agent.md
@@ -169,3 +169,16 @@ Only after explicit human confirmation, edit Markdown source files to replace ap
 - If a `linkchecker` run fails or a URL cannot be reached during crawling, flag affected links as "unverifiable" and include them for manual review.
 - Some URLs may return errors because they block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
 - Explicitly label recommendations as drafts that require human review.
+
+## Pushing changes to GitHub
+
+The `habitat-sh` organization enforces SAML SSO. A `git push` may fail with a 403 error even after a successful `gh auth refresh`. If this happens:
+
+1. Run `gh auth setup-git` to wire the refreshed token to the git credential helper.
+2. Retry `git push`.
+
+If the push still fails, ask the user to authorize the GitHub CLI for SAML SSO:
+
+1. Run `gh auth refresh --hostname github.com --scopes repo,read:org` and share the one-time code with the user.
+2. Ask the user to go to **https://github.com/login/device**, enter the code, and then select **Authorize** next to the `habitat-sh` organization in the SAML SSO section.
+3. After confirmation, run `gh auth setup-git` and retry `git push`.

--- a/.github/skills/link-checker/SKILL.md
+++ b/.github/skills/link-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Link Checker
-description: "Reusable skill that installs linkchecker (a Python CLI tool) and runs it against a live URL to produce a structured list of broken and redirected links. Use when an agent needs to verify URLs in a documentation site without fetching each link individually."
+description: "Reusable skill that runs linkchecker (a Python CLI tool) against a live URL to produce a structured list of broken and redirected links. Use when an agent needs to verify URLs in a documentation site without fetching each link individually. Requires linkchecker to be pre-installed — see Prerequisites."
 ---
 
 # Skill: Link Checker
@@ -15,25 +15,43 @@ Use this skill when an agent needs to:
 
 ## Prerequisites
 
-- Python 3.10 or later must be available in the environment
-- `pip` or `pipx` must be available for installation
+**linkchecker must be installed before using this skill.** The agent will not install it automatically.
 
-## Step 1 — Check whether linkchecker is installed
+Install once using [pipx](https://pipx.pypa.io/) (recommended, isolates the package in its own environment):
+
+```shell
+pipx install linkchecker
+```
+
+Or using pip into a virtual environment:
+
+```shell
+pip install linkchecker
+```
+
+Requires Python 3.10 or later. See the [linkchecker installation guide](https://linkchecker.github.io/linkchecker/install.html) for platform-specific instructions.
+
+**Why not auto-install?** Installing packages from PyPI at agent runtime — without explicit human awareness — is a supply chain security concern. The agent would be silently pulling in linkchecker and its dependencies (Requests, Beautiful Soup, dnspython) from the internet as a side effect of running a doc review. Requiring pre-installation means the human makes that decision deliberately.
+
+## Step 1 — Verify linkchecker is available
 
 ```powershell
 $lc = Get-Command linkchecker -ErrorAction SilentlyContinue
 if (-not $lc) {
-    Write-Host "linkchecker not found — installing with pipx..."
-    pipx install linkchecker
-    # After install, ensure pipx bin dir is on PATH for this session
-    $env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"
+    throw @"
+linkchecker is not installed or not on PATH.
+
+Install it before running this skill:
+  pipx install linkchecker   # recommended
+  pip install linkchecker    # alternative (use a virtual environment)
+
+See: https://linkchecker.github.io/linkchecker/install.html
+"@
 }
-$lc = Get-Command linkchecker -ErrorAction SilentlyContinue
-if (-not $lc) { throw "linkchecker installation failed. Ask the user to install it manually: pipx install linkchecker" }
-Write-Host "linkchecker available at: $($lc.Source)"
+Write-Host "linkchecker found at: $($lc.Source)"
 ```
 
-If installation fails, stop and ask the user to install linkchecker manually before continuing.
+Stop and surface the error message to the user if linkchecker is not found. Do not attempt to install it.
 
 ## Step 2 — Run linkchecker against the target URL
 
@@ -45,13 +63,13 @@ $targetUrl = "<target-url>"
 # --output=csv  : structured output for easy parsing
 # --check-extern: also check external links (not just internal)
 # --timeout=10  : per-link timeout in seconds
-# Linkchecker exits with code 0 (all OK) or non-zero (errors found) — capture output regardless
+# Linkchecker exits with non-zero when errors are found — capture output regardless
 $lcOutput = & linkchecker --no-robots --output=csv --check-extern --timeout=10 $targetUrl 2>&1
 Write-Host "linkchecker exit code: $LASTEXITCODE"
 ```
 
 **Note:** For large sites, linkchecker recurses through all pages by default. To limit scope to a single
-page (and its direct links only), add `--no-follow-url=<target-url>` or use `--depth=1`.
+page (and its direct links only), use `--depth=1`.
 
 ## Step 3 — Parse the CSV output
 
@@ -69,7 +87,7 @@ Key fields:
 - `line` / `col` — position in the parent page source
 
 ```powershell
-# Split output into lines; skip comment lines (start with #) and blank lines
+# Skip comment lines (start with #) and blank lines
 $csvLines = $lcOutput | Where-Object { $_ -notmatch "^#" -and $_.Trim() -ne "" }
 
 # Parse into objects (linkchecker CSV uses semicolons as delimiters)

--- a/.github/skills/link-checker/SKILL.md
+++ b/.github/skills/link-checker/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: Link Checker
+description: "Reusable skill that installs linkchecker (a Python CLI tool) and runs it against a live URL to produce a structured list of broken and redirected links. Use when an agent needs to verify URLs in a documentation site without fetching each link individually."
+---
+
+# Skill: Link Checker
+
+## When to use this skill
+
+Use this skill when an agent needs to:
+
+- Check all links on a published documentation site (or any live URL) for broken links, redirects, and errors
+- Avoid the token cost of fetching each URL individually with a web tool
+- Receive a structured, machine-readable report that the agent can then interpret and present to a human
+
+## Prerequisites
+
+- Python 3.10 or later must be available in the environment
+- `pip` or `pipx` must be available for installation
+
+## Step 1 — Check whether linkchecker is installed
+
+```powershell
+$lc = Get-Command linkchecker -ErrorAction SilentlyContinue
+if (-not $lc) {
+    Write-Host "linkchecker not found — installing with pipx..."
+    pipx install linkchecker
+    # After install, ensure pipx bin dir is on PATH for this session
+    $env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"
+}
+$lc = Get-Command linkchecker -ErrorAction SilentlyContinue
+if (-not $lc) { throw "linkchecker installation failed. Ask the user to install it manually: pipx install linkchecker" }
+Write-Host "linkchecker available at: $($lc.Source)"
+```
+
+If installation fails, stop and ask the user to install linkchecker manually before continuing.
+
+## Step 2 — Run linkchecker against the target URL
+
+Replace `<target-url>` with the URL to check (for example, `https://docs.chef.io/habitat/`).
+
+```powershell
+$targetUrl = "<target-url>"
+# --no-robots   : ignore robots.txt (documentation sites may block crawlers)
+# --output=csv  : structured output for easy parsing
+# --check-extern: also check external links (not just internal)
+# --timeout=10  : per-link timeout in seconds
+# Linkchecker exits with code 0 (all OK) or non-zero (errors found) — capture output regardless
+$lcOutput = & linkchecker --no-robots --output=csv --check-extern --timeout=10 $targetUrl 2>&1
+Write-Host "linkchecker exit code: $LASTEXITCODE"
+```
+
+**Note:** For large sites, linkchecker recurses through all pages by default. To limit scope to a single
+page (and its direct links only), add `--no-follow-url=<target-url>` or use `--depth=1`.
+
+## Step 3 — Parse the CSV output
+
+The CSV output from linkchecker has this header:
+
+```
+urlname;parentname;base;result;warningstring;infostring;valid;url;line;col;name;dltime;size;checktime
+```
+
+Key fields:
+- `urlname` — the URL that was checked
+- `result` — HTTP result or error message (for example, `200 OK`, `404 Not Found`, `301 Moved Permanently`)
+- `valid` — `True` or `False`
+- `parentname` — the page that contained the link
+- `line` / `col` — position in the parent page source
+
+```powershell
+# Split output into lines; skip comment lines (start with #) and blank lines
+$csvLines = $lcOutput | Where-Object { $_ -notmatch "^#" -and $_.Trim() -ne "" }
+
+# Parse into objects (linkchecker CSV uses semicolons as delimiters)
+$results = $csvLines | ConvertFrom-Csv -Delimiter ";"
+
+# Separate broken and redirected links
+$broken     = $results | Where-Object { $_.valid -eq "False" }
+$redirected = $results | Where-Object { $_.valid -eq "True" -and $_.result -match "^3\d\d" }
+
+Write-Host "Broken links:     $($broken.Count)"
+Write-Host "Redirected links: $($redirected.Count)"
+```
+
+## Step 4 — Return results to the calling agent
+
+Pass `$broken` and `$redirected` to the agent report-generation step. The calling agent formats these
+into a human-readable table grouped by parent page, with columns for URL, result, and parent page.
+
+```powershell
+# Example: display broken links
+$broken | Format-Table urlname, result, parentname -AutoSize
+```
+
+## Notes for calling agents
+
+- linkchecker crawls recursively by default. For a scoped check (single page), use `--depth=1`.
+- The CSV output may include a header row as a comment line (starting with `#`). The parse step above handles this.
+- linkchecker may report false positives for URLs that block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
+- `--no-robots` is recommended for documentation site checks to avoid missing pages excluded by `robots.txt`.
+- Do not treat a non-zero exit code from linkchecker as a script failure — it means errors were found, which is expected. Check `$broken.Count` instead.
+- This skill checks the **published site** (live HTML). It will not catch broken links in Markdown source that have not yet been published. The calling agent should also run pattern-based checks on the raw Markdown files for common issues such as `http://` URLs, `master` branch references, and known outdated domains.

--- a/.github/skills/link-checker/SKILL.md
+++ b/.github/skills/link-checker/SKILL.md
@@ -45,6 +45,10 @@ Install it before running this skill:
   pipx install linkchecker   # recommended
   pip install linkchecker    # alternative (use a virtual environment)
 
+After a pipx install, ensure the pipx bin directory is on PATH:
+  - Linux/macOS : $HOME/.local/bin  (add to ~/.bashrc or ~/.zshrc)
+  - Windows     : %USERPROFILE%\.local\bin  (or run: pipx ensurepath)
+
 See: https://linkchecker.github.io/linkchecker/install.html
 "@
 }
@@ -59,12 +63,12 @@ Replace `<target-url>` with the URL to check (for example, `https://docs.chef.io
 
 ```powershell
 $targetUrl = "<target-url>"
-# --no-robots   : ignore robots.txt (documentation sites may block crawlers)
-# --output=csv  : structured output for easy parsing
-# --check-extern: also check external links (not just internal)
-# --timeout=10  : per-link timeout in seconds
+# --no-robots        : ignore robots.txt (documentation sites may block crawlers)
+# --file-output=csv  : emit CSV to stdout (omitting a file path writes to stdout)
+# --check-extern     : also check external links (not just internal)
+# --timeout=10       : per-link timeout in seconds
 # Linkchecker exits with non-zero when errors are found — capture output regardless
-$lcOutput = & linkchecker --no-robots --output=csv --check-extern --timeout=10 $targetUrl 2>&1
+$lcOutput = & linkchecker --no-robots --file-output=csv --check-extern --timeout=10 $targetUrl 2>&1
 Write-Host "linkchecker exit code: $LASTEXITCODE"
 ```
 
@@ -87,11 +91,19 @@ Key fields:
 - `line` / `col` — position in the parent page source
 
 ```powershell
-# Skip comment lines (start with #) and blank lines
-$csvLines = $lcOutput | Where-Object { $_ -notmatch "^#" -and $_.Trim() -ne "" }
+# LinkChecker emits its CSV header as a comment line starting with "# urlname;..."
+# Extract and strip the leading "#" so ConvertFrom-Csv can use it as the header row,
+# then keep only non-comment, non-blank data lines.
+$headerLine = $lcOutput | Where-Object { $_ -match "^# urlname;" } | Select-Object -First 1
+$header     = $headerLine -replace "^#\s*", ""
+
+$dataLines  = $lcOutput | Where-Object { $_ -notmatch "^#" -and $_.Trim() -ne "" }
+
+# Prepend the extracted header so ConvertFrom-Csv maps columns correctly
+$csvContent = @($header) + $dataLines
 
 # Parse into objects (linkchecker CSV uses semicolons as delimiters)
-$results = $csvLines | ConvertFrom-Csv -Delimiter ";"
+$results = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
 # Separate broken and redirected links
 $broken     = $results | Where-Object { $_.valid -eq "False" }
@@ -114,7 +126,7 @@ $broken | Format-Table urlname, result, parentname -AutoSize
 ## Notes for calling agents
 
 - linkchecker crawls recursively by default. For a scoped check (single page), use `--depth=1`.
-- The CSV output may include a header row as a comment line (starting with `#`). The parse step above handles this.
+- The CSV output includes the column header as a `#`-prefixed comment line. The parse step above extracts and strips that prefix so `ConvertFrom-Csv` receives a proper header row.
 - linkchecker may report false positives for URLs that block automated crawlers (for example, LinkedIn). Flag these as "unverifiable" rather than broken.
 - `--no-robots` is recommended for documentation site checks to avoid missing pages excluded by `robots.txt`.
 - Do not treat a non-zero exit code from linkchecker as a script failure — it means errors were found, which is expected. Check `$broken.Count` instead.


### PR DESCRIPTION
## Summary

This PR implements Ian's suggestion to replace the per-URL web-fetch loop in the Link Reviewer agent with a [linkchecker](https://linkchecker.github.io/linkchecker/) skill invocation.

## Why this change

The current agent fetches each URL individually using its `web` tool — one LLM-driven tool call per link. For a documentation site with many pages and hundreds of links, this burns a large amount of token context and is slow.

`linkchecker` is a mature Python CLI tool that crawls a site and returns a structured CSV report in a single external invocation, making it far more efficient.

## What changed

### New file: `.github/skills/link-checker/SKILL.md`

A reusable skill that:
- Installs `linkchecker` via `pipx` if not already present
- Runs `linkchecker --no-robots --output=csv --check-extern --timeout=10 <url>` against the published docs site
- Parses the CSV output into structured `$broken` and `$redirected` lists for the agent to process

### Updated file: `.github/agents/link-reviewer.agent.md`

- Added `shell` to the allowed tools list (needed to run `linkchecker`)
- Replaced the per-URL fetch loop (Steps 2–3 in the old workflow) with a single Link Checker skill invocation
- Retained the Markdown pattern-check step (http→https, master→main, outdated domains) — these still require reading source files because linkchecker checks the published HTML site, not Markdown source
- All safety requirements, human-in-the-loop rules, and the report format are unchanged

## Design note

`linkchecker` works against live HTML, not Markdown source. The agent therefore:
1. Runs `linkchecker` against the published site (`https://docs.chef.io/habitat/`) for live URL verification
2. Separately pattern-checks raw Markdown files for source-level issues not yet published

This combination preserves all capabilities of the original agent while being significantly more efficient.

## Review checklist

- [ ] Skill instructions are clear and correct
- [ ] Agent workflow steps are coherent and complete
- [ ] Safety and human-review requirements are preserved
- [ ] `linkchecker` flags and options are appropriate for this use case